### PR TITLE
Added LOAD_MIO0_TEXTURE alias for backwards-compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This is a fork of the ultrasm64 repo by CrashOveride which includes the followin
 - **CrashOveride**: creating the [ultrasm64](https://github.com/CrashOveride95/ultrasm64) repo
 - **falcobuster**: Original coordinate overflow fix (world scale), ASM version of extended bounds
 - **anonymous_moose**: porting falco's extended bounds to decomp
+- **tuxlovesyou**: `LOAD_MIO0_TEXTURE` macro and moral support
 
 Thanks to Frame#5375 and AloXado320 for also helping with silhouette stuff
 

--- a/include/level_commands.h
+++ b/include/level_commands.h
@@ -310,6 +310,9 @@ enum GoddardScene {
     CMD_PTR(romEnd)
 #endif
 
+#undef LOAD_MIO0_TEXTURE
+#define LOAD_MIO0_TEXTURE(a,b,c) LOAD_YAY0_TEXTURE(a,b,c)
+
 #define CHANGE_AREA_SKYBOX(area, segStart, segEnd) \
     CMD_BBH(LEVEL_CMD_CHANGE_AREA_SKYBOX, 0x0C, area), \
     CMD_PTR(segStart), \


### PR DESCRIPTION
Sometimes tools like Fast64 will export script.c files with
LOAD_MIO0_TEXTURE() macro "calls" even when you have "YAY0" toggled
under the export menu.  To keep this from being a roadblock for
compilation, LOAD_MIO0_TEXTURE() is defined in this commit as an alias
to the LOAD_YAY0_TEXTURE() macro! :-)