### PR TITLE
Add beta triple jump define

### DIFF
--- a/include/config/config_movement.h
+++ b/include/config/config_movement.h
@@ -4,6 +4,25 @@
  * MOVEMENT SETTINGS *
  *********************/
 
+
+// Gives Mario the spinning triple jump found in the beta versions.
+// Most important setting in the file by far
+#define BETA_TRIPLE_JUMP
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 // Changes Mario's ground turn radius by making it dependent on the analog stick magnitude and speed.
 // #define VELOCITY_BASED_TURN_SPEED
 

--- a/src/game/mario_actions_moving.c
+++ b/src/game/mario_actions_moving.c
@@ -135,7 +135,13 @@ s32 set_triple_jump_action(struct MarioState *m, UNUSED u32 action, UNUSED u32 a
     if (m->flags & MARIO_WING_CAP) {
         return set_mario_action(m, ACT_FLYING_TRIPLE_JUMP, 0);
     } else if (m->forwardVel > 20.0f) {
+#ifdef BETA_TRIPLE_JUMP
+        m->vel[1] = 69.f;
+        m->forwardVel *= 0.8f;
+        return set_mario_action(m, ACT_TWIRLING, 0);
+#else
         return set_mario_action(m, ACT_TRIPLE_JUMP, 0);
+#endif
     } else {
         return set_mario_action(m, ACT_JUMP, 0);
     }


### PR DESCRIPTION
IMPORTANT! should be merged immediately

Adds a define to use the beta triple jump, the best thing to put in any hack ever. Uncommented by default of course because everyone wants this in their hack. You are welcome for making the repo so much better.