### PR TITLE
Tie JRB dark skybox with ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS

### DIFF
--- a/src/game/skybox.c
+++ b/src/game/skybox.c
@@ -290,10 +290,12 @@ Gfx *create_skybox_facing_camera(s8 player, s8 background, f32 fov, Vec3f pos, V
     s8 colorIndex = 1;
 
     // If the "Plunder in the Sunken Ship" star in JRB is collected, make the sky darker and slightly green
+#ifdef ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
     if (background == BACKGROUND_ABOVE_CLOUDS
         && !(save_file_get_star_flags(gCurrSaveFileNum - 1, COURSE_NUM_TO_INDEX(COURSE_JRB)) & STAR_FLAG_ACT_1)) {
         colorIndex = 0;
     }
+#endif
 
     //! fov is always set to 90.0f. If this line is removed, then the game crashes because fov is 0 on
     //! the first frame, which causes a floating point divide by 0


### PR DESCRIPTION
The JRB skybox is darkened if you haven't collected JRB's first star. This behaviour should be under ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS`-