### PR TITLE
Make bhv_init_room automatically detect if the current area has room data instead of checking a hardcoded array of level numbers.

### DIFF
--- a/include/config/config_game.h
+++ b/include/config/config_game.h
@@ -4,11 +4,8 @@
  * GAME SETTINGS *
  *****************/
 
-/** 
- * Enables some mechanics that change behavior depending on hardcoded level numbers.
- * You may also need to change sLevelsWithRooms in object_helpers.c
- * TODO: separate this into separate defines, behavior params, or make these mechanics otherwise dynamic
-*/
+// Enables some mechanics that change behavior depending on hardcoded level numbers.
+// TODO: separate this into separate defines, behavior params, or make these mechanics otherwise dynamic.
 // #define ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
 
 // Disable lives and hide the lives counter
@@ -62,7 +59,7 @@
 // If this is disabled, backup assets will be used.
 // #define COMPLETE_EN_US_SEGMENT2
 
-/// Removes multi-language cake screen
+// Removes multi-language cake screen
 #define EU_CUSTOM_CAKE_FIX
 
 // Adds multiple languages to the game. Just a placeholder for the most part, because it only works with EU, and must be enabled with EU.

--- a/src/game/object_helpers.c
+++ b/src/game/object_helpers.c
@@ -28,8 +28,6 @@
 #include "spawn_sound.h"
 #include "puppylights.h"
 
-static s8 sLevelsWithRooms[] = { LEVEL_BBH, LEVEL_CASTLE, LEVEL_HMC, -1 };
-
 static s32 clear_move_flag(u32 *bitSet, s32 flag);
 
 Gfx *geo_update_projectile_pos_from_parent(s32 callContext, UNUSED struct GraphNode *node, Mat4 mtx) {
@@ -1882,7 +1880,7 @@ s32 is_item_in_array(s8 item, s8 *array) {
 
 void bhv_init_room(void) {
     struct Surface *floor = NULL;
-    if (is_item_in_array(gCurrLevelNum, sLevelsWithRooms)) {
+    if (gCurrentArea->surfaceRooms != NULL) {
         find_room_floor(o->oPosX, o->oPosY, o->oPosZ, &floor);
 
         if (floor != NULL) {


### PR DESCRIPTION
This removes the need to manually change sLevelsWithRooms when importing/removing a roomed level.

I tested this with all roomed vanilla levels.

Importing a roomed level with Fast64 also needs to be tested if Fast64 changes sLevelsWithRooms automatically.