### PR TITLE
2.1.0 Benchmarking system

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -6,7 +6,6 @@
  */
 
 #include "config/config_audio.h"
-#include "config/config_benchmark.h"
 #include "config/config_camera.h"
 #include "config/config_collision.h"
 #include "config/config_cutscenes.h"
@@ -19,6 +18,7 @@
 #include "config/config_movement.h"
 #include "config/config_objects.h"
 #include "config/config_rom.h"
+#include "config/config_benchmark.h"
 
 
 /* WARNING: Compatibility safeguards - don't remove this file unless you know what you're doing */

--- a/include/config/config_benchmark.h
+++ b/include/config/config_benchmark.h
@@ -5,7 +5,9 @@
  **********************/
 /**
  * Enabling this will enable a set of defines in order to run a benchmark on the game
- * Currently this just starts the credits, and enables puppyprint debug
+ * It will initiate the credits, and then output the results to puppyprint's log.
+ * It is HIGHLY recommended you have UNF Reader enabled for this, which can be switched
+ * in the makefile.
 */
 
 // #define ENABLE_CREDITS_BENCHMARK
@@ -14,4 +16,10 @@
     #define DEBUG_ALL
     #define ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
     #define TEST_LEVEL LEVEL_CASTLE_GROUNDS
+    #define SKIP_TITLE_SCREEN
+    #define PUPPYPRINT
+    #define PUPPYPRINT_DEBUG 1
+    #undef DISABLE_ALL
+    #undef ENABLE_DEBUG_FREE_MOVE
+    #define UNLOCK_FPS
 #endif

--- a/levels/intro/script.c
+++ b/levels/intro/script.c
@@ -27,6 +27,11 @@
 
 const LevelScript level_intro_splash_screen[] = {
     INIT_LEVEL(),
+#ifdef ENABLE_CREDITS_BENCHMARK
+    SET_REG(LEVEL_CASTLE_GROUNDS),
+    JUMP_IF(/*op*/ OP_EQ, /*arg*/ 100, script_intro_main_level_entry),
+    EXIT_AND_EXECUTE(/*seg*/ 0x15, _scriptsSegmentRomStart, _scriptsSegmentRomEnd, level_main_scripts_entry),
+#endif
 #ifdef SKIP_TITLE_SCREEN
     EXIT_AND_EXECUTE_WITH_CODE(/*seg*/ SEGMENT_MENU_INTRO, _introSegmentRomStart, _introSegmentRomEnd, level_intro_mario_head_regular, _introSegmentBssStart, _introSegmentBssEnd),
 #endif

--- a/src/audio/internal.h
+++ b/src/audio/internal.h
@@ -61,7 +61,7 @@ enum Codecs {
 // Since u8 and u16 fit losslessly in both, behavior is the same.
 #define FLOAT_CAST(x) (f32) (s32) (x)
 
-#if defined(ISVPRINT) || defined(UNF)
+#if (defined(ISVPRINT) || defined(UNF)) && !defined(ENABLE_CREDITS_BENCHMARK)
 #define stubbed_printf osSyncPrintf
 #else
 

--- a/src/boot/memory.c
+++ b/src/boot/memory.c
@@ -405,7 +405,9 @@ void *load_segment_decompress(s32 segment, u8 *srcStart, u8 *srcEnd) {
         dest = main_pool_alloc(*size, MEMORY_POOL_LEFT);
 #endif
         if (dest != NULL) {
+#ifndef ENABLE_CREDITS_BENCHMARK
             osSyncPrintf("start decompress\n");
+#endif
 #ifdef GZIP
             expand_gzip(compressed, dest, compSize, (u32)size);
 #elif RNC1
@@ -417,7 +419,9 @@ void *load_segment_decompress(s32 segment, u8 *srcStart, u8 *srcEnd) {
 #elif MIO0
             decompress(compressed, dest);
 #endif
+#ifndef ENABLE_CREDITS_BENCHMARK
             osSyncPrintf("end decompress\n");
+#endif
             set_segment_base_addr(segment, dest);
             main_pool_free(compressed);
         }

--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -27,6 +27,7 @@
 #include "level_table.h"
 #include "config.h"
 #include "puppyprint.h"
+#include "debug.h"
 
 #define CBUTTON_MASK (U_CBUTTONS | D_CBUTTONS | L_CBUTTONS | R_CBUTTONS)
 
@@ -3121,6 +3122,9 @@ void update_camera(struct Camera *c) {
     profiler_update(cameraTime, first);
     cameraTime[perfIteration] -= collisionTime[perfIteration]-colTime;
 #endif
+#ifdef ENABLE_CREDITS_BENCHMARK
+    iterate_credits_benchmark();
+#endif
 }
 
 /**
@@ -3342,6 +3346,9 @@ void init_camera(struct Camera *c) {
     c->nextYaw = gLakituState.yaw;
 #ifdef PUPPYCAM
     puppycam_init();
+#endif
+#ifdef ENABLE_CREDITS_BENCHMARK
+    benchmark_scene_swap();
 #endif
 }
 

--- a/src/game/debug.h
+++ b/src/game/debug.h
@@ -56,5 +56,9 @@ extern void __n64Assert(char *fileName, u32 lineNum, char *message);
 #define assert(cond, message)
 #endif
 
+void iterate_credits_benchmark(void);
+void benchmark_scene_swap(void);
+void init_credits_benchmark(void);
+
 
 #endif // DEBUG_H

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -794,6 +794,11 @@ s16 level_trigger_warp(struct MarioState *m, s32 warpOp) {
                 }
                 fadeMusic = FALSE;
                 break;
+            case WARP_OP_CREDITS_SAME:
+                sDelayedWarpTimer = 20;
+                play_transition(WARP_TRANSITION_FADE_INTO_COLOR, sDelayedWarpTimer, 0x00, 0x00, 0x00);
+                fadeMusic = FALSE;
+                break;
         }
 
         if (fadeMusic && gCurrDemoInput == NULL) {
@@ -1237,9 +1242,9 @@ s32 init_level(void) {
 
 #if PUPPYPRINT_DEBUG
 #ifdef PUPPYPRINT_DEBUG_CYCLES
-    append_puppyprint_log("Level loaded in %dc", (s32)(osGetTime() - first));
+    append_puppyprint_log("Level %d loaded in %dc\n", gCurrLevelNum, (s32)(osGetTime() - first));
 #else
-    append_puppyprint_log("Level loaded in %dus", (s32)(OS_CYCLES_TO_USEC(osGetTime() - first)));
+    append_puppyprint_log("Level %d loaded in %dus\n",gCurrLevelNum, (s32)(OS_CYCLES_TO_USEC(osGetTime() - first)));
 #endif
 #endif
     return TRUE;
@@ -1329,6 +1334,20 @@ s32 lvl_set_current_level(UNUSED s16 initOrUpdate, s32 levelNum) {
  * Play the "thank you so much for to playing my game" sound.
  */
 s32 lvl_play_the_end_screen_sound(UNUSED s16 initOrUpdate, UNUSED s32 levelNum) {
+#ifdef ENABLE_CREDITS_BENCHMARK
+    append_puppyprint_log("Benchmark End\n");
+    /*append_puppyprint_log("░░░░░░░░░░░░░░░░░░░░\n");
+    append_puppyprint_log("░▄▀▄▀▀▀▀▄▀▄░░░░░░░░░\n");
+    append_puppyprint_log("░█░░░░░░░░▀▄░░░░░░▄░\n");
+    append_puppyprint_log("█░░▀░░▀░░░░░▀▄▄░░█░█\n");
+    append_puppyprint_log("█░▄░█▀░▄░░░░░░░▀▀░░█\n");
+    append_puppyprint_log("█░░▀▀▀▀░░░░░░░░░░░░█\n");
+    append_puppyprint_log("█░░░░░░░░░░░░░░░░░░█\n");
+    append_puppyprint_log("█░░░░░░░░░░░░░░░░░░█\n");
+    append_puppyprint_log("░█░░▄▄░░▄▄▄▄░░▄▄░░█░\n");
+    append_puppyprint_log("░█░▄▀█░▄▀░░█░▄▀█░▄▀░\n");
+    append_puppyprint_log("░░▀░░░▀░░░░░▀░░░▀░░░\n");*/
+#endif
     play_sound(SOUND_MENU_THANK_YOU_PLAYING_MY_GAME, gGlobalSoundSource);
     return TRUE;
 }

--- a/src/game/level_update.h
+++ b/src/game/level_update.h
@@ -28,7 +28,8 @@ enum WarpOperation {
     WARP_OP_DEMO_NEXT,
     WARP_OP_CREDITS_START,
     WARP_OP_CREDITS_NEXT,
-    WARP_OP_DEMO_END
+    WARP_OP_DEMO_END,
+    WARP_OP_CREDITS_SAME
 };
 
 enum SpecialWarpDestinations {

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -2470,6 +2470,11 @@ enum {
 };
 
 static s32 act_end_peach_cutscene(struct MarioState *m) {
+#ifdef ENABLE_CREDITS_BENCHMARK
+play_cutscene_music(SEQUENCE_ARGS(15, SEQ_LEVEL_WATER));
+level_trigger_warp(m, WARP_OP_CREDITS_NEXT);
+return 0;
+#endif
     switch (m->actionArg) {
         case END_PEACH_CUTSCENE_MARIO_FALLING:
             end_peach_cutscene_mario_falling(m);
@@ -2546,6 +2551,7 @@ static s32 act_credits_cutscene(struct MarioState *m) {
         }
     }
 
+#ifndef ENABLE_CREDITS_BENCHMARK
     if (m->actionTimer >= TIMER_CREDITS_SHOW) {
         if (m->actionState < 40) {
             m->actionState += 2;
@@ -2563,6 +2569,7 @@ static s32 act_credits_cutscene(struct MarioState *m) {
 
         override_viewport_and_clip(&sEndCutsceneVp, 0, 0, 0, 0);
     }
+#endif
 
     if (m->actionTimer == TIMER_CREDITS_PROGRESS) {
         reset_cutscene_msg_fade();
@@ -2573,7 +2580,17 @@ static s32 act_credits_cutscene(struct MarioState *m) {
     }
 
     if (m->actionTimer++ == TIMER_CREDITS_WARP) {
+/*#ifndef ENABLE_CREDITS_BENCHMARK
+        if (benchIteration == 0) {
+            benchIteration = 1;
+            level_trigger_warp(m, WARP_OP_CREDITS_SAME)
+        } else {
+            benchIteration = 0;
+            level_trigger_warp(m, WARP_OP_CREDITS_NEXT);
+        }
+#else*/
         level_trigger_warp(m, WARP_OP_CREDITS_NEXT);
+//#endif
     }
 
     m->marioObj->header.gfx.angle[1] += (gCurrCreditsEntry->actNum & 0xC0) << 8;

--- a/src/game/puppyprint.c
+++ b/src/game/puppyprint.c
@@ -48,11 +48,7 @@ a modern game engine's developer's console.
 #ifdef PUPPYPRINT
 
 ColorRGBA currEnv;
-#ifdef ENABLE_CREDITS_BENCHMARK
-u8 fDebug = TRUE;
-#else
 u8 fDebug = FALSE;
-#endif
 
 #if PUPPYPRINT_DEBUG
 s8 benchViewer  = FALSE;


### PR DESCRIPTION
Initial implementation of the benchmarking system.
Currently uses the old version of Puppyprint Debug as its focus.
Will switch it over to the 2.1.0 version when it's merged to the main 2.1.0 branch.
Still needs a no audio version implementing, but that's going to involve a bit of fiddling.