### PR TITLE
Added (emu-only) RCVI hack.

### DIFF
--- a/include/config/config_rom.h
+++ b/include/config/config_rom.h
@@ -33,3 +33,9 @@
  * Informs supported emulators to default to gamecube controller inputs.
  */
 // #define USE_GAMECUBE_CONTROLLER
+
+/**
+ * RCVI hack. Increases performance on emulator, and does nothing on console.
+ * Might break on some emulators. Use at your own risk, and don't use it unless you actually need the extra performance.
+ */
+// #define RCVI_HACK

--- a/include/config/config_rom.h
+++ b/include/config/config_rom.h
@@ -29,6 +29,7 @@
 #define BORDER_HEIGHT_CONSOLE  0
 #define BORDER_HEIGHT_EMULATOR 0
 
+<<<<<<< HEAD
 /**
  * Informs supported emulators to default to gamecube controller inputs.
  */
@@ -38,4 +39,8 @@
  * RCVI hack. Increases performance on emulator, and does nothing on console.
  * Might break on some emulators. Use at your own risk, and don't use it unless you actually need the extra performance.
  */
+=======
+// RCVI hack. Increases performance on emulator, and does nothing on console
+// Might break on some emulators. Use at your own risk, and don't use it unless you actually need the extra performance.
+>>>>>>> newline moment
 // #define RCVI_HACK

--- a/include/config/config_rom.h
+++ b/include/config/config_rom.h
@@ -29,7 +29,6 @@
 #define BORDER_HEIGHT_CONSOLE  0
 #define BORDER_HEIGHT_EMULATOR 0
 
-<<<<<<< HEAD
 /**
  * Informs supported emulators to default to gamecube controller inputs.
  */
@@ -39,8 +38,4 @@
  * RCVI hack. Increases performance on emulator, and does nothing on console.
  * Might break on some emulators. Use at your own risk, and don't use it unless you actually need the extra performance.
  */
-=======
-// RCVI hack. Increases performance on emulator, and does nothing on console
-// Might break on some emulators. Use at your own risk, and don't use it unless you actually need the extra performance.
->>>>>>> newline moment
 // #define RCVI_HACK

--- a/src/audio/synthesis.c
+++ b/src/audio/synthesis.c
@@ -60,7 +60,7 @@
  * Generally speaking, a sound that doesn't seem to be fading at a natural rate is a parameter red flag (also known as feedback).
  * 
  * This is also known to cause severe lag on emulators that have counter factor set to 2 or greater.
- * If this is an issue, it is recommended you enable RCVI hack in the ROM's configuration. Alternatively, you can reduce the reverb parameters here to compensate.
+ * If this is an issue, it is recommended you enable RCVI hack in the config files. Alternatively, you can reduce the reverb parameters here to compensate.
  */
 
 

--- a/src/audio/synthesis.c
+++ b/src/audio/synthesis.c
@@ -68,7 +68,7 @@
 // Setting this to 4 corrupts the game, so set this value to -1 to use vanilla reverb if this is too slow, or if it just doesn't fit the desired aesthetic of a level.
 // You can change this value before audio_reset_session gets called if different levels can tolerate the demand better than others or just have different reverb goals.
 // A higher downsample value hits the game's frequency limit sooner, which can cause the reverb sometimes to be off pitch. This is a vanilla quirk (and also counter intuitive).
-// Higher downsample values also result in slightly shorter reverb decay times, so keep this in mind if balancing reverb presence with emulator, or maybe consider adjusting REVERB_WET_SIGNAL with a console check.
+// Higher downsample values also result in slightly shorter reverb decay times, so keep this in mind if balancing reverb presence with emulator, or maybe consider adjusting REVERB_REV_INDEX with a console check.
 s8 betterReverbDownsampleConsole = 2;
 
 // Larger values downsample the reverb exponentially by multiples of 2. A value of 1 doesn't downsample at all. This can substantially increase performance at the cost of resolution.
@@ -76,7 +76,7 @@ s8 betterReverbDownsampleConsole = 2;
 // Using a value of 1 is not recommended on emulator unless RCVI hack is enabled or other parameters are reduced to compensate. If you do decide to use 1 here, you must adjust BETTER_REVERB_SIZE appropriately.
 // You can change this value before audio_reset_session gets called if different levels can tolerate the demand better than others or just have different reverb goals.
 // A higher downsample value hits the game's frequency limit sooner, which can cause the reverb sometimes to be off pitch. This is a vanilla quirk (and also counter intuitive).
-// Higher downsample values also result in slightly shorter reverb decay times, so keep this in mind if balancing reverb presence with console, or maybe consider adjusting REVERB_WET_SIGNAL with a console check.
+// Higher downsample values also result in slightly shorter reverb decay times, so keep this in mind if balancing reverb presence with console, or maybe consider adjusting REVERB_REV_INDEX with a console check.
 s8 betterReverbDownsampleEmulator = 2;
 
 // This value represents the number of filters to use with the reverb. This can be decreased to improve performance, but at the cost of a lesser presence of reverb in the final audio.
@@ -292,7 +292,7 @@ void set_better_reverb_buffers(void) {
         delaysR[i] = (delaysBaselineR[i] / gReverbDownsampleRate);
         delayBufsL[i] = (s32*) &delayBufsL[0][bufOffset];
         bufOffset += delaysL[i];
-        delayBufsR[i] = (s32*) &delayBufsL[0][bufOffset]; // L and R buffers are interpolated adjacently in memory; not a bug
+        delayBufsR[i] = (s32*) &delayBufsL[0][bufOffset]; // L and R buffers are interleaved adjacently in memory; not a bug
         bufOffset += delaysR[i];
     }
 }

--- a/src/audio/synthesis.c
+++ b/src/audio/synthesis.c
@@ -60,22 +60,23 @@
  * Generally speaking, a sound that doesn't seem to be fading at a natural rate is a parameter red flag (also known as feedback).
  * 
  * This is also known to cause severe lag on emulators that have counter factor set to 2 or greater.
- * Be sure either you alert the user in advance, or check for and set betterReverbDownsampleEmulator to -1 if it's detected the user isn't using good settings.
- * Reducing performance heavy parameters or using RCVI hack may be another working solution to this problem.
+ * If this is an issue, it is recommended you enable RCVI hack in the ROM's configuration. Alternatively, you can reduce the reverb parameters here to compensate.
  */
 
 
+// Larger values downsample the reverb exponentially by multiples of 2. A value of 1 doesn't downsample at all. This can substantially increase performance at the cost of resolution.
 // Setting this to 4 corrupts the game, so set this value to -1 to use vanilla reverb if this is too slow, or if it just doesn't fit the desired aesthetic of a level.
 // You can change this value before audio_reset_session gets called if different levels can tolerate the demand better than others or just have different reverb goals.
-// A higher downsample value hits the game's frequency limit sooner, which can cause the reverb sometimes to be off pitch. This is a vanilla level issue (and also counter intuitive).
-// Higher downsample values also result in slightly shorter reverb decay times.
+// A higher downsample value hits the game's frequency limit sooner, which can cause the reverb sometimes to be off pitch. This is a vanilla quirk (and also counter intuitive).
+// Higher downsample values also result in slightly shorter reverb decay times, so keep this in mind if balancing reverb presence with emulator, or maybe consider adjusting REVERB_WET_SIGNAL with a console check.
 s8 betterReverbDownsampleConsole = 2;
 
-// Most emulators can handle a default value of 2, but 3 may be advisable in some cases if targeting older emulators (e.g. PJ64 1.6). Setting this to -1 also uses vanilla reverb.
-// Using a value of 1 is not recommended on emulator unless reducing other parameters to compensate. If you do decide to use 1 here, you must adjust BETTER_REVERB_SIZE appropriately.
+// Larger values downsample the reverb exponentially by multiples of 2. A value of 1 doesn't downsample at all. This can substantially increase performance at the cost of resolution.
+// Most emulators can handle a default value of 2, but 3 may be advisable as a failsafe against a counter factor of 2 (if RCVI hack is disabled). Setting this to -1 also uses vanilla reverb.
+// Using a value of 1 is not recommended on emulator unless RCVI hack is enabled or other parameters are reduced to compensate. If you do decide to use 1 here, you must adjust BETTER_REVERB_SIZE appropriately.
 // You can change this value before audio_reset_session gets called if different levels can tolerate the demand better than others or just have different reverb goals.
-// A higher downsample value hits the game's frequency limit sooner, which can cause the reverb sometimes to be off pitch. This is a vanilla level issue (and also counter intuitive).
-// Higher downsample values also result in slightly shorter reverb decay times.
+// A higher downsample value hits the game's frequency limit sooner, which can cause the reverb sometimes to be off pitch. This is a vanilla quirk (and also counter intuitive).
+// Higher downsample values also result in slightly shorter reverb decay times, so keep this in mind if balancing reverb presence with console, or maybe consider adjusting REVERB_WET_SIGNAL with a console check.
 s8 betterReverbDownsampleEmulator = 2;
 
 // This value represents the number of filters to use with the reverb. This can be decreased to improve performance, but at the cost of a lesser presence of reverb in the final audio.
@@ -410,7 +411,7 @@ void prepare_reverb_ring_buffer(s32 chunkLen, u32 updateIndex) {
                     reverb_mono_sample(&gSynthesisReverb.ringBuffer.left[dstPos], ((s32) item->toDownsampleLeft[srcPos] + (s32) item->toDownsampleRight[srcPos]) / 2);
                     gSynthesisReverb.ringBuffer.right[dstPos] = gSynthesisReverb.ringBuffer.left[dstPos];
                 }
-            } else { // Too slow for practical use, not recommended most of the time.
+            } else {
                 for (dstPos = item->startPos; dstPos < ((item->lengthA / 2) + item->startPos); dstPos++) {
                     reverb_mono_sample(&gSynthesisReverb.ringBuffer.left[dstPos], ((s32) gSynthesisReverb.ringBuffer.left[dstPos] + (s32) gSynthesisReverb.ringBuffer.right[dstPos]) / 2);
                     gSynthesisReverb.ringBuffer.right[dstPos] = gSynthesisReverb.ringBuffer.left[dstPos];
@@ -427,7 +428,7 @@ void prepare_reverb_ring_buffer(s32 chunkLen, u32 updateIndex) {
                     reverb_samples(&gSynthesisReverb.ringBuffer.left[dstPos], &gSynthesisReverb.ringBuffer.right[dstPos], item->toDownsampleLeft[srcPos], item->toDownsampleRight[srcPos]);
                 for (dstPos = 0; dstPos < (item->lengthB / 2); srcPos += gReverbDownsampleRate, dstPos++)
                     reverb_samples(&gSynthesisReverb.ringBuffer.left[dstPos], &gSynthesisReverb.ringBuffer.right[dstPos], item->toDownsampleLeft[srcPos], item->toDownsampleRight[srcPos]);
-            } else { // Too slow for practical use, not recommended most of the time.
+            } else {
                 for (dstPos = item->startPos; dstPos < ((item->lengthA / 2) + item->startPos); dstPos++)
                     reverb_samples(&gSynthesisReverb.ringBuffer.left[dstPos], &gSynthesisReverb.ringBuffer.right[dstPos], gSynthesisReverb.ringBuffer.left[dstPos], gSynthesisReverb.ringBuffer.right[dstPos]);
                 for (dstPos = 0; dstPos < (item->lengthB / 2); dstPos++)

--- a/src/boot/main.c
+++ b/src/boot/main.c
@@ -132,24 +132,6 @@ void create_thread(OSThread *thread, OSId id, void (*entry)(void *), void *arg, 
 extern void func_sh_802f69cc(void);
 #endif
 
-void change_vi(OSViMode *mode, int width, int height){
-    mode->comRegs.width  = width;
-    mode->comRegs.xScale = ((width * 512) / 320);
-    if (height > 240) {
-        mode->comRegs.ctrl     |= 0x40;
-        mode->fldRegs[0].origin = (width * 2);
-        mode->fldRegs[1].origin = (width * 4);
-        mode->fldRegs[0].yScale = (0x2000000 | ((height * 1024) / 240));
-        mode->fldRegs[1].yScale = (0x2000000 | ((height * 1024) / 240));
-        mode->fldRegs[0].vStart = (mode->fldRegs[1].vStart - 0x20002);
-    } else {
-        mode->fldRegs[0].origin = (width * 2);
-        mode->fldRegs[1].origin = (width * 4);
-        mode->fldRegs[0].yScale = ((height * 1024) / 240);
-        mode->fldRegs[1].yScale = ((height * 1024) / 240);
-    }
-}
-
 void handle_nmi_request(void) {
     gResetTimer = 1;
     gNmiResetBarsTimer = 0;
@@ -352,9 +334,7 @@ void check_cache_emulation() {
 }
 
 extern void crash_screen_init(void);
-#ifdef RCVI_HACK
 extern OSViMode VI;
-#endif
 void thread3_main(UNUSED void *arg) {
     setup_mesg_queues();
     alloc_pool();
@@ -482,6 +462,24 @@ void turn_off_audio(void) {
     gAudioEnabled = FALSE;
     while (sCurrentAudioSPTask != NULL) {
         ;
+    }
+}
+
+void change_vi(OSViMode *mode, int width, int height) {
+    mode->comRegs.width  = width;
+    mode->comRegs.xScale = ((width * 512) / 320);
+    if (height > 240) {
+        mode->comRegs.ctrl     |= 0x40;
+        mode->fldRegs[0].origin = (width * 2);
+        mode->fldRegs[1].origin = (width * 4);
+        mode->fldRegs[0].yScale = (0x2000000 | ((height * 1024) / 240));
+        mode->fldRegs[1].yScale = (0x2000000 | ((height * 1024) / 240));
+        mode->fldRegs[0].vStart = (mode->fldRegs[1].vStart - 0x20002);
+    } else {
+        mode->fldRegs[0].origin = (width * 2);
+        mode->fldRegs[1].origin = (width * 4);
+        mode->fldRegs[0].yScale = ((height * 1024) / 240);
+        mode->fldRegs[1].yScale = ((height * 1024) / 240);
     }
 }
 

--- a/src/boot/main.c
+++ b/src/boot/main.c
@@ -132,6 +132,24 @@ void create_thread(OSThread *thread, OSId id, void (*entry)(void *), void *arg, 
 extern void func_sh_802f69cc(void);
 #endif
 
+void change_vi(OSViMode *mode, int width, int height){
+    mode->comRegs.width  = width;
+    mode->comRegs.xScale = ((width * 512) / 320);
+    if (height > 240) {
+        mode->comRegs.ctrl     |= 0x40;
+        mode->fldRegs[0].origin = (width * 2);
+        mode->fldRegs[1].origin = (width * 4);
+        mode->fldRegs[0].yScale = (0x2000000 | ((height * 1024) / 240));
+        mode->fldRegs[1].yScale = (0x2000000 | ((height * 1024) / 240));
+        mode->fldRegs[0].vStart = (mode->fldRegs[1].vStart - 0x20002);
+    } else {
+        mode->fldRegs[0].origin = (width * 2);
+        mode->fldRegs[1].origin = (width * 4);
+        mode->fldRegs[0].yScale = ((height * 1024) / 240);
+        mode->fldRegs[1].yScale = ((height * 1024) / 240);
+    }
+}
+
 void handle_nmi_request(void) {
     gResetTimer = 1;
     gNmiResetBarsTimer = 0;
@@ -464,24 +482,6 @@ void turn_off_audio(void) {
     gAudioEnabled = FALSE;
     while (sCurrentAudioSPTask != NULL) {
         ;
-    }
-}
-
-void change_vi(OSViMode *mode, int width, int height){
-    mode->comRegs.width  = width;
-    mode->comRegs.xScale = ((width * 512) / 320);
-    if (height > 240) {
-        mode->comRegs.ctrl     |= 0x40;
-        mode->fldRegs[0].origin = (width * 2);
-        mode->fldRegs[1].origin = (width * 4);
-        mode->fldRegs[0].yScale = (0x2000000 | ((height * 1024) / 240));
-        mode->fldRegs[1].yScale = (0x2000000 | ((height * 1024) / 240));
-        mode->fldRegs[0].vStart = (mode->fldRegs[1].vStart - 0x20002);
-    } else {
-        mode->fldRegs[0].origin = (width * 2);
-        mode->fldRegs[1].origin = (width * 4);
-        mode->fldRegs[0].yScale = ((height * 1024) / 240);
-        mode->fldRegs[1].yScale = ((height * 1024) / 240);
     }
 }
 

--- a/src/boot/main.c
+++ b/src/boot/main.c
@@ -368,7 +368,7 @@ void thread3_main(UNUSED void *arg) {
             gCacheEmulated = FALSE;
         }
 #ifdef RCVI_HACK
-        VI.comRegs.vSync = 525*4;   
+        VI.comRegs.vSync = 525*20;   
         change_vi(&VI, SCREEN_WIDTH, SCREEN_HEIGHT);
         osViSetMode(&VI);
         osViSetSpecialFeatures(OS_VI_DITHER_FILTER_ON);

--- a/src/boot/main.c
+++ b/src/boot/main.c
@@ -334,7 +334,9 @@ void check_cache_emulation() {
 }
 
 extern void crash_screen_init(void);
-
+#ifdef RCVI_HACK
+extern OSViMode VI;
+#endif
 void thread3_main(UNUSED void *arg) {
     setup_mesg_queues();
     alloc_pool();
@@ -365,6 +367,13 @@ void thread3_main(UNUSED void *arg) {
         } else {
             gCacheEmulated = FALSE;
         }
+#ifdef RCVI_HACK
+        VI.comRegs.vSync = 525*4;   
+        change_vi(&VI, SCREEN_WIDTH, SCREEN_HEIGHT);
+        osViSetMode(&VI);
+        osViSetSpecialFeatures(OS_VI_DITHER_FILTER_ON);
+        osViSetSpecialFeatures(OS_VI_GAMMA_OFF);
+#endif
     } else {
         gIsConsole = TRUE;
         gBorderHeight = BORDER_HEIGHT_CONSOLE;

--- a/src/game/main.h
+++ b/src/game/main.h
@@ -87,5 +87,6 @@ extern s8 gShowDebugText;
 void set_vblank_handler(s32 index, struct VblankHandler *handler, OSMesgQueue *queue, OSMesg *msg);
 void dispatch_audio_sptask(struct SPTask *spTask);
 void exec_display_list(struct SPTask *spTask);
+void change_vi(OSViMode *mode, int width, int height);
 
 #endif // MAIN_H


### PR DESCRIPTION
This should always be disabled by default.

Fixes #359 