### PR TITLE
Add VERTICAL_ROOMS define

### DIFF
--- a/include/config/config_collision.h
+++ b/include/config/config_collision.h
@@ -17,6 +17,9 @@
 // Number of walls that can push Mario at once. Vanilla is 4.
 #define MAX_REFERENCED_WALLS 4
 
+// Allow vertical rooms to be a thing by using the SURFACE_INTANGIBLE floor type to separate the rooms. Note that this will add an extra floor check every frame.
+// #define VERTICAL_ROOMS
+
 // Collision data is the type that the collision system uses. All data by default is stored as an s16, but you may change it to s32.
 // Naturally, that would double the size of all collision data, but would allow you to use 32 bit values instead of 16.
 // Rooms are s8 in vanilla, but if you somehow have more than 255 rooms, you may raise this number.

--- a/src/game/object_helpers.c
+++ b/src/game/object_helpers.c
@@ -130,16 +130,21 @@ Gfx *geo_switch_area(s32 callContext, struct GraphNode *node, UNUSED void *conte
         if (gMarioObject == NULL) {
             switchCase->selectedCase = 0;
         } else {
-#ifdef ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
-            if (gCurrLevelNum == LEVEL_BBH) {
-                // In BBH, check for a floor manually, since there is an intangible floor. In custom hacks this can be removed.
+#ifdef VERTICAL_ROOMS
+                // Checks for a floor manually, including intangible ones. This allows one to have vertical rooms.
                 find_room_floor(gMarioObject->oPosX, gMarioObject->oPosY, gMarioObject->oPosZ, &floor);
-            } else {
-                // Since no intangible floors are nearby, use Mario's floor instead.
-                floor = gMarioState->floor;
-            }
 #else
-            floor = gMarioState->floor;
+#ifdef ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
+                if (gCurrLevelNum == LEVEL_BBH) {
+                    find_room_floor(gMarioObject->oPosX, gMarioObject->oPosY, gMarioObject->oPosZ, &floor);
+                } else {
+                    floor = gMarioState->floor;
+                }
+#else
+                // Use Mario's floor to determine the room. 
+                // This saves processing time, but does not allow vertical rooms, since intangible floors will be skipped.
+                floor = gMarioState->floor;
+#endif
 #endif
             if (floor) {
                 gMarioCurrentRoom = floor->room;


### PR DESCRIPTION
Allows for vertical rooms

- If `VERTICAL ROOMS` is enabled, `geo_switch_area` will do a manual floor check every frame to check for intangible floors.
- If `VERTICAL_ROOMS` is disabled:
  - If `ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS` is enabled, do a manual floor check ONLY in BBH (this vanilla level is the only that uses vertical cloors)
  - if `ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS` is disabled, never do a manual floor check.