### PR TITLE
Simplified lives defines

### DIFF
--- a/include/config/config_game.h
+++ b/include/config/config_game.h
@@ -22,19 +22,19 @@
 #define SAVE_NUM_LIVES
 
 /**
- * This is the number of lives Mario starts with after a game over or starting the game for the first time (must be lower than 127).
+ * Enable lives and the lives counter. The number next to the define is the number of lives you start with.
  */
-#define DEFAULT_NUM_LIVES 4
+// #define ENABLE_LIVES 4
 
 /**
  * This can be 0..127.
  */
-#define MAX_NUM_LIVES   100
+#define MAX_NUM_LIVES 100
 
 /**
  * This can be 0..32767.
  */
-#define MAX_NUM_COINS   999
+#define MAX_NUM_COINS 999
 
 /**
  * Air/breath meter is separate from health meter when underwater.

--- a/include/config/config_game.h
+++ b/include/config/config_game.h
@@ -12,11 +12,6 @@
 // #define ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
 
 /**
- * Disables lives and hides the lives counter.
- */
-#define DISABLE_LIVES
-
-/**
  * Saves the number of lives to the save file (Does nothing if DISABLE_LIVES is enabled).
  */
 #define SAVE_NUM_LIVES

--- a/include/config/config_game.h
+++ b/include/config/config_game.h
@@ -12,11 +12,6 @@
 // #define ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
 
 /**
- * Saves the number of lives to the save file (Does nothing if DISABLE_LIVES is enabled).
- */
-#define SAVE_NUM_LIVES
-
-/**
  * Enable lives and the lives counter. The number next to the define is the number of lives you start with.
  */
 // #define ENABLE_LIVES 4

--- a/include/config/config_safeguards.h
+++ b/include/config/config_safeguards.h
@@ -151,10 +151,6 @@
  * config_game.h
  */
 
-#ifdef DISABLE_LIVES
-    #undef SAVE_NUM_LIVES
-#endif // DISABLE_LIVES
-
 #ifndef START_LEVEL
     #define START_LEVEL LEVEL_CASTLE_GROUNDS
 #endif // !START_LEVEL

--- a/src/game/behaviors/mushroom_1up.inc.c
+++ b/src/game/behaviors/mushroom_1up.inc.c
@@ -10,9 +10,6 @@ void bhv_1up_interact(void) {
 #endif
 #endif
         gMarioState->numLives++;
-#ifdef SAVE_NUM_LIVES
-        save_file_set_num_lives(gMarioState->numLives);
-#endif
         o->activeFlags = ACTIVE_FLAG_DEACTIVATED;
 #if ENABLE_RUMBLE
         queue_rumble_data(5, 80);

--- a/src/game/behaviors/mushroom_1up.inc.c
+++ b/src/game/behaviors/mushroom_1up.inc.c
@@ -9,7 +9,9 @@ void bhv_1up_interact(void) {
         gMarioState->breathCounter = 31;
 #endif
 #endif
+#ifdef ENABLE_LIVES
         gMarioState->numLives++;
+#endif
         o->activeFlags = ACTIVE_FLAG_DEACTIVATED;
 #if ENABLE_RUMBLE
         queue_rumble_data(5, 80);

--- a/src/game/behaviors/yoshi.inc.c
+++ b/src/game/behaviors/yoshi.inc.c
@@ -146,9 +146,6 @@ void yoshi_give_present_loop(void) {
     s32 globalTimer = gGlobalTimer;
 
     if (gHudDisplay.lives == 100) {
-#ifdef SAVE_NUM_LIVES
-        save_file_set_num_lives(gMarioState->numLives);
-#endif
         play_sound(SOUND_GENERAL_COLLECT_1UP, gGlobalSoundSource);
         gSpecialTripleJump = TRUE;
         o->oAction = YOSHI_ACT_WALK_JUMP_OFF_ROOF;

--- a/src/game/behaviors/yoshi.inc.c
+++ b/src/game/behaviors/yoshi.inc.c
@@ -146,7 +146,7 @@ void yoshi_give_present_loop(void) {
 #ifdef ENABLE_LIVES
     s32 globalTimer = gGlobalTimer;
 
-    if (gHudDisplay.lives == 100) {
+    if (gHudDisplay.lives == MAX_NUM_LIVES) {
         play_sound(SOUND_GENERAL_COLLECT_1UP, gGlobalSoundSource);
         gSpecialTripleJump = TRUE;
         o->oAction = YOSHI_ACT_WALK_JUMP_OFF_ROOF;

--- a/src/game/behaviors/yoshi.inc.c
+++ b/src/game/behaviors/yoshi.inc.c
@@ -143,6 +143,7 @@ void yoshi_finish_jumping_and_despawn_loop(void) {
 }
 
 void yoshi_give_present_loop(void) {
+#ifdef ENABLE_LIVES
     s32 globalTimer = gGlobalTimer;
 
     if (gHudDisplay.lives == 100) {
@@ -156,6 +157,12 @@ void yoshi_give_present_loop(void) {
         play_sound(SOUND_MENU_YOSHI_GAIN_LIVES, gGlobalSoundSource);
         gMarioState->numLives++;
     }
+#else
+    play_sound(SOUND_GENERAL_COLLECT_1UP, gGlobalSoundSource);
+    gSpecialTripleJump = TRUE;
+    o->oAction = YOSHI_ACT_WALK_JUMP_OFF_ROOF;
+    return;
+#endif
 }
 
 void bhv_yoshi_loop(void) {

--- a/src/game/hud.c
+++ b/src/game/hud.c
@@ -27,7 +27,7 @@
  **/
 
 #ifdef BREATH_METER
-// #ifdef DISABLE_LIVES
+// #ifndef ENABLE_LIVES
 // #define HUD_BREATH_METER_X         64
 // #define HUD_BREATH_METER_Y        200
 // #define HUD_BREATH_METER_HIDDEN_Y 300
@@ -562,7 +562,7 @@ void render_hud(void) {
             render_hud_cannon_reticle();
         }
 
-#ifndef DISABLE_LIVES
+#ifdef ENABLE_LIVES
         if (hudDisplayFlags & HUD_DISPLAY_FLAG_LIVES) {
             render_hud_mario_lives();
         }

--- a/src/game/hud.c
+++ b/src/game/hud.c
@@ -27,15 +27,9 @@
  **/
 
 #ifdef BREATH_METER
-// #ifndef ENABLE_LIVES
-// #define HUD_BREATH_METER_X         64
-// #define HUD_BREATH_METER_Y        200
-// #define HUD_BREATH_METER_HIDDEN_Y 300
-// #else
 #define HUD_BREATH_METER_X         40
 #define HUD_BREATH_METER_Y         32
 #define HUD_BREATH_METER_HIDDEN_Y -20
-// #endif
 #endif
 
 // ------------- FPS COUNTER ---------------

--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -1993,7 +1993,7 @@ void print_hud_course_complete_coins(s16 x, s16 y) {
             gCourseCompleteCoins++;
             play_sound(SOUND_MENU_YOSHI_GAIN_LIVES, gGlobalSoundSource);
 
-#ifndef DISABLE_LIVES
+#ifdef ENABLE_LIVES
             if (gCourseCompleteCoins && ((gCourseCompleteCoins % 50) == 0)) {
                 play_sound(SOUND_GENERAL_COLLECT_1UP, gGlobalSoundSource);
                 gMarioState->numLives++;
@@ -2137,9 +2137,6 @@ s32 render_course_complete_screen(void) {
         case DIALOG_STATE_OPENING:
             render_course_complete_lvl_info_and_hud_str();
             if (gCourseDoneMenuTimer > 100 && gCourseCompleteCoinsEqual) {
-#ifdef SAVE_NUM_LIVES
-                save_file_set_num_lives(gMarioState->numLives);
-#endif
                 gDialogBoxState = DIALOG_STATE_VERTICAL;
                 level_set_transition(-1, NULL);
                 gDialogTextAlpha = 0;

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -698,9 +698,6 @@ s16 level_trigger_warp(struct MarioState *m, s32 warpOp) {
     s32 fadeMusic = TRUE;
 
     if (sDelayedWarpOp == WARP_OP_NONE) {
-#ifdef SAVE_NUM_LIVES
-        save_file_set_num_lives(m->numLives);
-#endif
         m->invincTimer = -1;
         sDelayedWarpArg = WARP_FLAGS_NONE;
         sDelayedWarpOp = warpOp;
@@ -731,7 +728,7 @@ s16 level_trigger_warp(struct MarioState *m, s32 warpOp) {
                 break;
 
             case WARP_OP_DEATH:
-#ifndef DISABLE_LIVES
+#ifdef ENABLE_LIVES
                 if (m->numLives == 0) {
                     sDelayedWarpOp = WARP_OP_GAME_OVER;
                 }
@@ -748,7 +745,7 @@ s16 level_trigger_warp(struct MarioState *m, s32 warpOp) {
             case WARP_OP_WARP_FLOOR:
                 sSourceWarpNodeId = WARP_NODE_WARP_FLOOR;
                 if (area_get_warp_node(sSourceWarpNodeId) == NULL) {
-#ifndef DISABLE_LIVES
+#ifdef ENABLE_LIVES
                     if (m->numLives == 0) {
                         sDelayedWarpOp = WARP_OP_GAME_OVER;
                     } else {
@@ -916,16 +913,9 @@ void update_hud_values(void) {
             }
         }
 
-#ifdef SAVE_NUM_LIVES
-        if (gMarioState->numLives > MAX_NUM_LIVES) {
-            gMarioState->numLives = MAX_NUM_LIVES;
-            save_file_set_num_lives(MAX_NUM_LIVES);
-        }
-#else
         if (gMarioState->numLives > 100) {
             gMarioState->numLives = 100;
         }
-#endif
 
 #if BUGFIX_MAX_LIVES
         if (gMarioState->numCoins > 999) {

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -914,17 +914,17 @@ void update_hud_values(void) {
         }
 
 #ifdef ENABLE_LIVES
-        if (gMarioState->numLives > 100) {
-            gMarioState->numLives = 100;
+        if (gMarioState->numLives > MAX_NUM_LIVES) {
+            gMarioState->numLives = MAX_NUM_LIVES;
         }
 #endif
 
-        if (gMarioState->numCoins > 999) {
-            gMarioState->numCoins = 999;
+        if (gMarioState->numCoins > MAX_NUM_COINS) {
+            gMarioState->numCoins = MAX_NUM_COINS;
         }
 
-        if (gHudDisplay.coins > 999) {
-            gHudDisplay.coins = 999;
+        if (gHudDisplay.coins > MAX_NUM_COINS) {
+            gHudDisplay.coins = MAX_NUM_COINS;
         }
 
         gHudDisplay.stars = gMarioState->numStars;

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -913,11 +913,12 @@ void update_hud_values(void) {
             }
         }
 
+#ifdef ENABLE_LIVES
         if (gMarioState->numLives > 100) {
             gMarioState->numLives = 100;
         }
+#endif
 
-#if BUGFIX_MAX_LIVES
         if (gMarioState->numCoins > 999) {
             gMarioState->numCoins = 999;
         }
@@ -925,11 +926,6 @@ void update_hud_values(void) {
         if (gHudDisplay.coins > 999) {
             gHudDisplay.coins = 999;
         }
-#else
-        if (gMarioState->numCoins > 999) {
-            gMarioState->numLives = (s8) 999; //! Wrong variable
-        }
-#endif
 
         gHudDisplay.stars = gMarioState->numStars;
         gHudDisplay.lives = gMarioState->numLives;

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -1871,12 +1871,10 @@ void init_mario_from_save_file(void) {
     gMarioState->numCoins = 0;
     gMarioState->numStars = save_file_get_total_star_count(gCurrSaveFileNum - 1, COURSE_MIN - 1, COURSE_MAX - 1);
     gMarioState->numKeys = 0;
-
-#ifdef SAVE_NUM_LIVES
-    s8 savedLives = save_file_get_num_lives();
-    gMarioState->numLives = (savedLives > DEFAULT_NUM_LIVES) ? savedLives : DEFAULT_NUM_LIVES;
+#ifdef ENABLE_LIVES
+    gMarioState->numLives = ENABLE_LIVES;
 #else
-    gMarioState->numLives = DEFAULT_NUM_LIVES;
+    gMarioState->numLives = 99;
 #endif
     gMarioState->health = 0x880;
 #ifdef BREATH_METER

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -1874,7 +1874,7 @@ void init_mario_from_save_file(void) {
 #ifdef ENABLE_LIVES
     gMarioState->numLives = ENABLE_LIVES;
 #else
-    gMarioState->numLives = 99;
+    gMarioState->numLives = 0;
 #endif
     gMarioState->health = 0x880;
 #ifdef BREATH_METER

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -1178,9 +1178,8 @@ s32 act_death_exit(struct MarioState *m) {
 #if ENABLE_RUMBLE
         queue_rumble_data(5, 80);
 #endif
+#ifdef ENABLE_LIVES
         m->numLives--;
-#ifdef SAVE_NUM_LIVES
-        save_file_set_num_lives(m->numLives);
 #endif
         // restore 7.75 units of health
         m->healCounter = 31;
@@ -1196,9 +1195,8 @@ s32 act_death_exit(struct MarioState *m) {
 s32 act_unused_death_exit(struct MarioState *m) {
     if (launch_mario_until_land(m, ACT_FREEFALL_LAND_STOP, MARIO_ANIM_GENERAL_FALL, 0.0f)) {
         play_sound(SOUND_MARIO_OOOF2, m->marioObj->header.gfx.cameraToObject);
+#ifdef ENABLE_LIVES
         m->numLives--;
-#ifdef SAVE_NUM_LIVES
-        save_file_set_num_lives(m->numLives);
 #endif
         // restore 7.75 units of health
         m->healCounter = 31;
@@ -1217,9 +1215,8 @@ s32 act_falling_death_exit(struct MarioState *m) {
 #if ENABLE_RUMBLE
         queue_rumble_data(5, 80);
 #endif
+#ifdef ENABLE_LIVES
         m->numLives--;
-#ifdef SAVE_NUM_LIVES
-        save_file_set_num_lives(m->numLives);
 #endif
         // restore 7.75 units of health
         m->healCounter = 31;
@@ -1273,9 +1270,8 @@ s32 act_special_death_exit(struct MarioState *m) {
 #if ENABLE_RUMBLE
         queue_rumble_data(5, 80);
 #endif
+#ifdef ENABLE_LIVES
         m->numLives--;
-#ifdef SAVE_NUM_LIVES
-        save_file_set_num_lives(m->numLives);
 #endif
         m->healCounter = 31;
     }

--- a/src/game/save_file.c
+++ b/src/game/save_file.c
@@ -658,11 +658,7 @@ void save_file_set_cap_pos(s16 x, s16 y, s16 z) {
 
     saveFile->capLevel = gCurrLevelNum;
     saveFile->capArea = gCurrAreaIndex;
-#ifndef SAVE_NUM_LIVES
     vec3s_set(saveFile->capPos, x, y, z);
-#else
-    (void) x; (void) y; (void) z; // Address compiler warnings for unused variables
-#endif
     save_file_set_flags(SAVE_FLAG_CAP_ON_GROUND);
 }
 
@@ -672,29 +668,11 @@ s32 save_file_get_cap_pos(Vec3s capPos) {
 
     if (saveFile->capLevel == gCurrLevelNum && saveFile->capArea == gCurrAreaIndex
         && (flags & SAVE_FLAG_CAP_ON_GROUND)) {
-#ifdef SAVE_NUM_LIVES
-        vec3_zero(capPos);
-#else
         vec3s_copy(capPos, saveFile->capPos);
-#endif
         return TRUE;
     }
     return FALSE;
 }
-
-#ifdef SAVE_NUM_LIVES
-void save_file_set_num_lives(s8 numLives) {
-    struct SaveFile *saveFile = &gSaveBuffer.files[gCurrSaveFileNum - 1][0];
-    saveFile->numLives = numLives;
-    saveFile->flags |= SAVE_FLAG_FILE_EXISTS;
-    gSaveFileModified = TRUE;
-}
-
-s32 save_file_get_num_lives(void) {
-    struct SaveFile *saveFile = &gSaveBuffer.files[gCurrSaveFileNum - 1][0];
-    return saveFile->numLives;
-}
-#endif
 
 void save_file_set_sound_mode(u16 mode) {
     set_sound_mode(mode);

--- a/src/game/save_file.h
+++ b/src/game/save_file.h
@@ -30,14 +30,9 @@ struct SaveFile {
     // cap can always be found in a fixed spot within the course
     u8 capLevel;
     u8 capArea;
-#ifdef SAVE_NUM_LIVES
-    s8 numLives;
-    u8 filler[5];
-#else
     // Note: the coordinates get set, but are never actually used, since the
     // cap can always be found in a fixed spot within the course
     Vec3s capPos; // 48 bits
-#endif
 
     u32 flags;
 
@@ -190,10 +185,6 @@ s32 save_file_is_cannon_unlocked(void);
 void save_file_set_cannon_unlocked(void);
 void save_file_set_cap_pos(s16 x, s16 y, s16 z);
 s32 save_file_get_cap_pos(Vec3s capPos);
-#ifdef SAVE_NUM_LIVES
-s32 save_file_get_num_lives(void);
-void save_file_set_num_lives(s8 numLives);
-#endif
 void save_file_set_sound_mode(u16 mode);
 u32 save_file_get_sound_mode(void);
 #ifdef WIDE


### PR DESCRIPTION
`ENABLE_LIVES` and `DEFAULT_NUM_LIVES` are now the same define. 

Also, `SAVE_NUM_LIVES` has been removed since it was a super chonky define that, realistically, no one is going to use. 

Fixes #433 
Fixes #438 