### PR TITLE
Clear only used dynamic cells

### DIFF
--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -144,11 +144,11 @@ static void add_surface_to_cell(s32 dynamic, s32 cellX, s32 cellZ, struct Surfac
         if (sNumCellsUsed >= sizeof(sCellsUsed) / sizeof(struct CellCoords)) {
             sClearAllCells = TRUE;
         } else {
-            u32 addNew = FALSE;
+            u32 addNew = TRUE;
             for (u32 i = 0; i < NUM_SPATIAL_PARTITIONS; i++) {
-                addNew = gDynamicSurfacePartition[cellZ][cellX][i].next == NULL;
-                if (addNew) {
-                    break;
+                if (gDynamicSurfacePartition[cellZ][cellX][i].next != NULL) {
+                addNew = FALSE;
+                break;
                 }
             }
             if (addNew) {

--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -23,6 +23,8 @@
  */
 SpatialPartitionCell gStaticSurfacePartition[NUM_CELLS][NUM_CELLS];
 SpatialPartitionCell gDynamicSurfacePartition[NUM_CELLS][NUM_CELLS];
+u8 sCellsUsed[NUM_CELLS][NUM_CELLS];
+u16 sNumCellsUsed;
 
 /**
  * Pools of data that can contain either surface nodes or surfaces.
@@ -134,6 +136,9 @@ static void add_surface_to_cell(s32 dynamic, s32 cellX, s32 cellZ, struct Surfac
 
     if (dynamic) {
         list = &gDynamicSurfacePartition[cellZ][cellX][listIndex];
+        sCellsUsed[sNumCellsUsed][1] = cellX;
+        sCellsUsed[sNumCellsUsed][0] = cellZ;
+        sNumCellsUsed++;
     } else {
         list = &gStaticSurfacePartition[cellZ][cellX][listIndex];
     }
@@ -478,6 +483,8 @@ void load_area_terrain(s32 index, TerrainData *data, RoomData *surfaceRooms, s16
     gEnvironmentRegions = NULL;
     gSurfaceNodesAllocated = 0;
     gSurfacesAllocated = 0;
+    bzero(&sCellsUsed, sizeof(sCellsUsed));
+    sNumCellsUsed = 0;
 
     clear_static_surfaces();
 
@@ -539,7 +546,15 @@ void clear_dynamic_surfaces(void) {
 
         gDynamicSurfacePoolEnd = gDynamicSurfacePool;
 
-        clear_spatial_partition(&gDynamicSurfacePartition[0][0]);
+        for (u32 i = 0; i < sNumCellsUsed; i++) {
+            gDynamicSurfacePartition[sCellsUsed[i][0]][sCellsUsed[i][1]][0].next = NULL;
+            gDynamicSurfacePartition[sCellsUsed[i][0]][sCellsUsed[i][1]][1].next = NULL;
+            gDynamicSurfacePartition[sCellsUsed[i][0]][sCellsUsed[i][1]][2].next = NULL;
+            gDynamicSurfacePartition[sCellsUsed[i][0]][sCellsUsed[i][1]][3].next = NULL;
+        }
+        sNumCellsUsed = 0;
+
+        //clear_spatial_partition(&gDynamicSurfacePartition[0][0]);
     }
 }
 

--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -503,7 +503,7 @@ void load_area_terrain(s32 index, TerrainData *data, RoomData *surfaceRooms, s16
     gSurfacesAllocated = 0;
     bzero(&sCellsUsed, sizeof(sCellsUsed));
     sNumCellsUsed = 0;
-    sClearAllCells = FALSE;
+    sClearAllCells = TRUE;
 
     clear_static_surfaces();
 

--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -147,8 +147,8 @@ static void add_surface_to_cell(s32 dynamic, s32 cellX, s32 cellZ, struct Surfac
             u32 addNew = TRUE;
             for (u32 i = 0; i < NUM_SPATIAL_PARTITIONS; i++) {
                 if (gDynamicSurfacePartition[cellZ][cellX][i].next != NULL) {
-                addNew = FALSE;
-                break;
+                    addNew = FALSE;
+                    break;
                 }
             }
             if (addNew) {
@@ -563,14 +563,14 @@ void clear_dynamic_surfaces(void) {
         gSurfacesAllocated = gNumStaticSurfaces;
         gSurfaceNodesAllocated = gNumStaticSurfaceNodes;
         gDynamicSurfacePoolEnd = gDynamicSurfacePool;
-        if (sClearAllCells == FALSE) {
+        if (sClearAllCells) {
+            clear_spatial_partition(&gDynamicSurfacePartition[0][0]);
+        } else {
             for (u32 i = 0; i < sNumCellsUsed; i++) {
                 for (u32 j = 0; j < NUM_SPATIAL_PARTITIONS; j++) {
                     gDynamicSurfacePartition[sCellsUsed[i].z][sCellsUsed[i].x][j].next = NULL;
                 }
             }
-        } else {
-            clear_spatial_partition(&gDynamicSurfacePartition[0][0]);
         }
         sNumCellsUsed = 0;
         sClearAllCells = FALSE;

--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -141,7 +141,7 @@ static void add_surface_to_cell(s32 dynamic, s32 cellX, s32 cellZ, struct Surfac
 
     if (dynamic) {
         list = &gDynamicSurfacePartition[cellZ][cellX][listIndex];
-        if (sNumCellsUsed > sizeof(sCellsUsed) / sizeof(struct CellCoords)) {
+        if (sNumCellsUsed >= sizeof(sCellsUsed) / sizeof(struct CellCoords)) {
             sClearAllCells = TRUE;
         } else {
             u32 addNew = FALSE;


### PR DESCRIPTION
Saves a lot of CPU over silliness, clearing the final hurdle to just using 4x bounds at all times.