### PR TITLE
Restore exit course sound effect

### DIFF
--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -410,7 +410,7 @@ void init_mario_after_warp(void) {
         }
 
         if (sWarpDest.levelNum == LEVEL_CASTLE && sWarpDest.areaIdx == 1
-            && (sWarpDest.nodeId == 31 || sWarpDest.nodeId == 32)
+            && (sWarpDest.nodeId == 32)
         ) {
             play_sound(SOUND_MENU_MARIO_CASTLE_WARP, gGlobalSoundSource);
         }
@@ -418,6 +418,13 @@ void init_mario_after_warp(void) {
         if (sWarpDest.levelNum == LEVEL_CASTLE_GROUNDS && sWarpDest.areaIdx == 1
             && (sWarpDest.nodeId == 7 || sWarpDest.nodeId == 10 || sWarpDest.nodeId == 20
                 || sWarpDest.nodeId == 30)) {
+            play_sound(SOUND_MENU_MARIO_CASTLE_WARP, gGlobalSoundSource);
+        }
+#endif
+#ifndef DISABLE_EXIT_COURSE
+       if (sWarpDest.levelNum == EXIT_COURSE_LEVEL && sWarpDest.areaIdx == EXIT_COURSE_AREA
+            && sWarpDest.nodeId == EXIT_COURSE_NODE
+        ) {
             play_sound(SOUND_MENU_MARIO_CASTLE_WARP, gGlobalSoundSource);
         }
 #endif


### PR DESCRIPTION
This is a partial solution of issue #286.

This decouples the exit course sound from `ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS`, allowing it to play as long as `DISABLE_EXIT_COURSE` is not defined and `EXIT_COURSE_LEVEL`, `EXIT_COURSE_AREA`, and `EXIT_COURSE_NODE` point to a valid warp. However, the lack of an exit sound for non-lethal warps, such as voiding out of the vanish cap stage, voiding out of TotWC, and similar, isn't fixed by this pull request.

Currently, `init_mario_after_warp` checks against a hard-coded list of `nodeId` values to determine if the sound effect should be played. The vast majority of these are within `LEVEL_CASTLE_GROUNDS`, with one in `LEVEL_CASTLE` checking for a `nodeId` of 32 that I'm unsure of the function of. This will have to be overhauled to fix the other component of the issue.

