### PR TITLE
Restore dither effect on teleport

### DIFF
--- a/src/game/mario_misc.c
+++ b/src/game/mario_misc.c
@@ -309,7 +309,7 @@ static Gfx *make_gfx_mario_alpha(struct GraphNodeGenerated *node, s16 alpha) {
         SET_GRAPH_NODE_LAYER(node->fnNode.node.flags, LAYER_TRANSPARENT);
         gfxHead = alloc_display_list(3 * sizeof(*gfxHead));
         gfx = gfxHead;
-        if (gMarioState->flags & MARIO_VANISH_CAP) {
+        if (gMarioState->flags & (MARIO_VANISH_CAP | MARIO_TELEPORTING)) {
             gDPSetAlphaCompare(gfx++, G_AC_DITHER);
         } else {
             gDPSetAlphaCompare(gfx++, G_AC_NONE);


### PR DESCRIPTION
#473

Mario now uses `G_AC_DITHER` if he's either using the vanish cap or teleporting, `G_AC_NONE` otherwise. Previously, the code only checked for vanish cap state, leading to the issue above.