### PR TITLE
Clean up remaining DISABLE_LEVEL_CHECKS ifndefs

### DIFF
--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -550,9 +550,9 @@ s16 music_unchanged_through_warp(s16 arg) {
 
     s16 destArea = warpNode->node.destArea;
     s16 unchanged = TRUE;
-    s16 currBgMusic;
 
 #ifdef ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
+    s16 currBgMusic;
     if (levelNum == LEVEL_BOB && levelNum == gCurrLevelNum && destArea == gCurrAreaIndex) {
         currBgMusic = get_current_background_music();
         if (currBgMusic == SEQUENCE_ARGS(4, SEQ_EVENT_POWERUP | SEQ_VARIATION)

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -552,7 +552,7 @@ s16 music_unchanged_through_warp(s16 arg) {
     s16 unchanged = TRUE;
     s16 currBgMusic;
 
-#ifndef DISABLE_LEVEL_SPECIFIC_CHECKS
+#ifdef ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
     if (levelNum == LEVEL_BOB && levelNum == gCurrLevelNum && destArea == gCurrAreaIndex) {
         currBgMusic = get_current_background_music();
         if (currBgMusic == SEQUENCE_ARGS(4, SEQ_EVENT_POWERUP | SEQ_VARIATION)
@@ -570,7 +570,7 @@ s16 music_unchanged_through_warp(s16 arg) {
         if (get_current_background_music() != destParam2) {
             unchanged = FALSE;
         }
-#ifndef DISABLE_LEVEL_SPECIFIC_CHECKS
+#ifdef ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
     }
 #endif
     return unchanged;

--- a/src/game/puppycam2.c
+++ b/src/game/puppycam2.c
@@ -486,7 +486,7 @@ void puppycam_init(void) {
     gPuppyCam.targetObj2 = NULL;
 
     gPuppyCam.intendedFlags = PUPPYCAM_BEHAVIOUR_DEFAULT;
-#ifndef DISABLE_LEVEL_SPECIFIC_CHECKS
+#ifdef ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
     if (gCurrLevelNum == LEVEL_PSS || (gCurrLevelNum == LEVEL_TTM && gCurrAreaIndex == 2) || (gCurrLevelNum == LEVEL_CCM && gCurrAreaIndex == 2)) {
         gPuppyCam.intendedFlags |= PUPPYCAM_BEHAVIOUR_SLIDE_CORRECTION;
     }


### PR DESCRIPTION
This replaces the remaining `DISABLE_LEVEL_CHECKS` `ifndefs` with correct `ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS` `ifdefs`. One of the vanilla checks in `src/game/level_update.c` appears to do the same thing as another vanilla check in the same file (namely, make double super extra sure the slide music doesn't get canceled going through a warp in BOB); could we look into whether we could remove one of those?