### PR TITLE
Fix CROSS variable on multiple environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,20 +114,10 @@ else ifeq ($(GRUCODE),super3d) # Super3D
   DEFINES += SUPER3D_GBI=1 F3D_NEW=1
 endif
 
-LIBRARIES := nustd hvqm2 z goddard
-
 # TEXT ENGINES
 #   s2dex_text_engine - Text Engine by someone2639
 TEXT_ENGINE := none
-ifeq ($(TEXT_ENGINE), s2dex_text_engine)
-  DEFINES += S2DEX_GBI_2=1 S2DEX_TEXT_ENGINE=1
-  LIBRARIES += s2d_engine
-  DUMMY != make -C src/s2d_engine COPY_DIR=$(shell pwd)/lib/
-endif
-# add more text engines here
-
-LINK_LIBRARIES = $(foreach i,$(LIBRARIES),-l$(i))
-
+$(eval $(call validate-option,TEXT_ENGINE,none s2dex_text_engine))
 
 #==============================================================================#
 # Optimization flags                                                           #
@@ -436,6 +426,18 @@ else ifneq ($(call find-command,mips-ld),)
 else
   $(error Unable to detect a suitable MIPS toolchain installed)
 endif
+
+LIBRARIES := nustd hvqm2 z goddard
+
+# Text engine
+ifeq ($(TEXT_ENGINE), s2dex_text_engine)
+  DEFINES += S2DEX_GBI_2=1 S2DEX_TEXT_ENGINE=1
+  LIBRARIES += s2d_engine
+  DUMMY != $(MAKE) -C src/s2d_engine COPY_DIR=$(shell pwd)/lib/ CROSS=$(CROSS)
+endif
+# add more text engines here
+
+LINK_LIBRARIES = $(foreach i,$(LIBRARIES),-l$(i))
 
 export LD_LIBRARY_PATH=./tools
 

--- a/src/s2d_engine/Makefile
+++ b/src/s2d_engine/Makefile
@@ -10,7 +10,6 @@ DUMMY != mkdir -p $(BUILD_DIR)
 C_FILES = $(wildcard ./*.c)
 O_FILES = $(foreach file,$(C_FILES),$(BUILD_DIR)/$(file:.c=.o))
 
-CROSS := mips-linux-gnu-
 CC = $(CROSS)gcc
 AR = $(CROSS)ar
 

--- a/tools/calc_bss.sh
+++ b/tools/calc_bss.sh
@@ -18,8 +18,24 @@ if [ -z "$QEMU_IRIX" ]; then
     exit 1
 fi
 
+# detect prefix for MIPS toolchain unless CROSS is already defined
 if [ -z "$CROSS" ]; then
+  if command -v mips64-elf-ld &> /dev/null ; then
+    CROSS=mips64-elf-
+  elif command -v mips-n64-ld &> /dev/null ; then
+    CROSS=mips-n64-
+  elif command -v mips64-ld &> /dev/null ; then
+    CROSS=mips64-
+  elif command -v mips-linux-gnu-ld &> /dev/null ; then
     CROSS=mips-linux-gnu-
+  elif command -v mips64-linux-gnu-ld &> /dev/null ; then
+    CROSS=mips64-linux-gnu-
+  elif command -v mips-ld &> /dev/null ; then
+    CROSS=mips-
+  else
+    echo "Unable to detect a suitable MIPS toolchain installed"
+    exit 1
+  fi
 fi
 
 # bss indexing starts at 3


### PR DESCRIPTION
Compiling the project with S2DEX text engine enabled doesn't work on Arch Linux, and neither does the tools/calc_bss.sh script. This commit fixes that.

I'm not really satisfied with how the main Makefile is now structured. I had to move the s2d_engine section down below where CROSS is set for it to work, which isn't great for readability. Suggestions are welcome, as I'm not very experienced with Makefiles.