### PR TITLE
Add define for using JP red coin sound

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,7 @@
 # These owners will be the default owners for everything in the repo.
 *       @Reonu
 *       @thecozies
-*       @Mr-Wiseguy
+*       @gheskett
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners

--- a/include/config/config_audio.h
+++ b/include/config/config_audio.h
@@ -10,6 +10,11 @@
 #define PERSISTENT_CAP_MUSIC
 
 /**
+ * Red coins should use the unchanging JP sound effect.
+ */
+// #define JP_RED_COIN_SOUND
+
+/**
  * Increase audio heap size to allow for larger/more custom sequences/banks/sfx to be imported without causing issues (not supported for SH).
  * Note that this is REQUIRED in order to use the extended 0C audio bank. Do not disable this if you're planning on using it. 
  */

--- a/sound/sequences/00_sound_player.s
+++ b/sound/sequences/00_sound_player.s
@@ -4088,16 +4088,9 @@ layer_note1 31, 0x14, 127
 layer_end
 
 .sound_general_red_coin:
-#if defined(VERSION_EU) || defined(VERSION_SH)
-  chan_setbank 9
-  chan_setinstr 3
-#else
-  chan_setinstr 128
-#endif
-chan_setenvelope .envelope_3378
-// Small bugfix: .main_loop_023589 expects layer 0 to live the longest.
-// I don't think this actually makes any audible difference given the
-// silence at the end.
+chan_setbank 9
+chan_setinstr 3
+# chan_setenvelope .envelope_3378 // Envelope for EU/SH not authentic to JP sound
 chan_setlayer 0, .layer_1907
 chan_setlayer 1, .layer_1902
 chan_setlayer 2, .layer_1909

--- a/src/game/behaviors/red_coin.inc.c
+++ b/src/game/behaviors/red_coin.inc.c
@@ -54,10 +54,15 @@ void bhv_red_coin_loop(void) {
                 spawn_orange_number(o->parentObj->oHiddenStarTriggerCounter, 0, 0, 0);
             }
 
+#ifdef JP_RED_COIN_SOUND
+            // For JP version, play an identical sound for all coins.
+            create_sound_spawner(SOUND_GENERAL_RED_COIN);
+#else
             // On all versions but the JP version, each coin collected plays a higher noise.
             play_sound(SOUND_MENU_COLLECT_RED_COIN
                        + (((u8) o->parentObj->oHiddenStarTriggerCounter - 1) << 16),
                        gGlobalSoundSource);
+#endif
         }
 
         coin_collected();


### PR DESCRIPTION
Please merge sooner than later, as this is potentially useful as an additional reference to variable red coin counts with 9+ reds.