### PR TITLE
Make objects not run their code if the room they are in isn't loaded.

### DIFF
--- a/data/behavior_data.c
+++ b/data/behavior_data.c
@@ -2626,6 +2626,7 @@ const BehaviorScript bhvExclamationBox[] = {
     OR_INT(oFlags, OBJ_FLAG_UPDATE_GFX_POS_AND_ANGLE),
     SET_FLOAT(oCollisionDistance, 300),
     SET_HOME(),
+    CALL_NATIVE(bhv_init_room),
     BEGIN_LOOP(),
         CALL_NATIVE(bhv_exclamation_box_loop),
     END_LOOP(),
@@ -3772,6 +3773,7 @@ const BehaviorScript bhvMessagePanel[] = {
     DROP_TO_FLOOR(),
     SET_HITBOX(/*Radius*/ 150, /*Height*/ 80),
     SET_INT(oWoodenPostTotalMarioAngle, 0),
+    CALL_NATIVE(bhv_init_room),
     CALL_NATIVE(load_object_static_model),
     BEGIN_LOOP(),
         SET_INT(oIntangibleTimer, 0),
@@ -5600,6 +5602,7 @@ const BehaviorScript bhvActivatedBackAndForthPlatform[] = {
 const BehaviorScript bhvRecoveryHeart[] = {
     BEGIN(OBJ_LIST_LEVEL),
     OR_INT(oFlags, (OBJ_FLAG_COMPUTE_ANGLE_TO_MARIO | OBJ_FLAG_COMPUTE_DIST_TO_MARIO | OBJ_FLAG_UPDATE_GFX_POS_AND_ANGLE)),
+    CALL_NATIVE(bhv_init_room),
     BEGIN_LOOP(),
         CALL_NATIVE(bhv_recovery_heart_loop),
     END_LOOP(),

--- a/include/object_constants.h
+++ b/include/object_constants.h
@@ -55,7 +55,7 @@ enum ObjFlags {
     OBJ_FLAG_OCCLUDE_SILHOUETTE                = (1 << 20), // 0x00100000
     OBJ_FLAG_OPACITY_FROM_CAMERA_DIST          = (1 << 21), // 0x00200000
     OBJ_FLAG_EMIT_LIGHT                        = (1 << 22), // 0x00400000
-    OBJ_FLAG_PROCESS_OUTSIDE_ROOM              = (1 << 23), // 0x00400000
+    OBJ_FLAG_PROCESS_OUTSIDE_ROOM              = (1 << 23), // 0x00800000
     OBJ_FLAG_HITBOX_WAS_SET                    = (1 << 30), // 0x40000000
 };
 

--- a/include/object_constants.h
+++ b/include/object_constants.h
@@ -55,6 +55,7 @@ enum ObjFlags {
     OBJ_FLAG_OCCLUDE_SILHOUETTE                = (1 << 20), // 0x00100000
     OBJ_FLAG_OPACITY_FROM_CAMERA_DIST          = (1 << 21), // 0x00200000
     OBJ_FLAG_EMIT_LIGHT                        = (1 << 22), // 0x00400000
+    OBJ_FLAG_PROCESS_OUTSIDE_ROOM              = (1 << 23), // 0x00400000
     OBJ_FLAG_HITBOX_WAS_SET                    = (1 << 30), // 0x40000000
 };
 

--- a/src/engine/behavior_script.c
+++ b/src/engine/behavior_script.c
@@ -821,8 +821,10 @@ void cur_obj_update(void) {
     s32 bhvProcResult;
 
     if (!(objFlags & OBJ_FLAG_PROCESS_OUTSIDE_ROOM)) {
-        if (o->oRoom != -1 && gMarioCurrentRoom != 0 && !is_room_loaded(o->oRoom)) {
-            cur_obj_enable_rendering_if_mario_in_room();
+        if (o->oRoom != -1 && gMarioCurrentRoom != 0 && !is_room_loaded()) {
+            cur_obj_disable_rendering();
+            o->activeFlags |= ACTIVE_FLAG_IN_DIFFERENT_ROOM;
+            gNumRoomedObjectsNotInMarioRoom++;
             return;
         }
     }

--- a/src/engine/behavior_script.c
+++ b/src/engine/behavior_script.c
@@ -820,6 +820,13 @@ void cur_obj_update(void) {
     BhvCommandProc bhvCmdProc;
     s32 bhvProcResult;
 
+    if (!(objFlags & OBJ_FLAG_PROCESS_OUTSIDE_ROOM)) {
+        if (o->oRoom != -1 && gMarioCurrentRoom != 0 && !is_room_loaded(o->oRoom)) {
+            cur_obj_enable_rendering_if_mario_in_room();
+            return;
+        }
+    }
+
     // Calculate the distance from the object to Mario.
     if (objFlags & OBJ_FLAG_COMPUTE_DIST_TO_MARIO) {
         o->oDistanceToMario = dist_between_objects(o, gMarioObject);

--- a/src/game/object_helpers.c
+++ b/src/game/object_helpers.c
@@ -1891,7 +1891,7 @@ void bhv_init_room(void) {
     o->oRoom = -1;
 }
 
-u32 is_room_loaded(s32 room) {
+u32 is_room_loaded(void) {
     return gMarioCurrentRoom == o->oRoom
             || gDoorAdjacentRooms[gMarioCurrentRoom][0] == o->oRoom
             || gDoorAdjacentRooms[gMarioCurrentRoom][1] == o->oRoom;
@@ -1899,7 +1899,7 @@ u32 is_room_loaded(s32 room) {
 
 void cur_obj_enable_rendering_if_mario_in_room(void) {
     if (o->oRoom != -1 && gMarioCurrentRoom != 0) {
-        if (is_room_loaded(o->oRoom)) {
+        if (is_room_loaded()) {
             cur_obj_enable_rendering();
             o->activeFlags &= ~ACTIVE_FLAG_IN_DIFFERENT_ROOM;
             gNumRoomedObjectsInMarioRoom++;

--- a/src/game/object_helpers.c
+++ b/src/game/object_helpers.c
@@ -1891,15 +1891,15 @@ void bhv_init_room(void) {
     o->oRoom = -1;
 }
 
+u32 is_room_loaded(s32 room) {
+    return gMarioCurrentRoom == o->oRoom
+            || gDoorAdjacentRooms[gMarioCurrentRoom][0] == o->oRoom
+            || gDoorAdjacentRooms[gMarioCurrentRoom][1] == o->oRoom;
+}
+
 void cur_obj_enable_rendering_if_mario_in_room(void) {
     if (o->oRoom != -1 && gMarioCurrentRoom != 0) {
-        register s32 marioInRoom = (
-            gMarioCurrentRoom == o->oRoom
-            || gDoorAdjacentRooms[gMarioCurrentRoom][0] == o->oRoom
-            || gDoorAdjacentRooms[gMarioCurrentRoom][1] == o->oRoom
-        );
-
-        if (marioInRoom) {
+        if (is_room_loaded(o->oRoom)) {
             cur_obj_enable_rendering();
             o->activeFlags &= ~ACTIVE_FLAG_IN_DIFFERENT_ROOM;
             gNumRoomedObjectsInMarioRoom++;

--- a/src/game/object_helpers.h
+++ b/src/game/object_helpers.h
@@ -235,6 +235,7 @@ void cur_obj_call_action_function(ObjActionFunc actionFunctions[]);
 s32 cur_obj_mario_far_away(void);
 s32 is_mario_moving_fast_or_in_air(s32 speedThreshold);
 s32 is_item_in_array(s8 item, s8 *array);
+u32 is_room_loaded(s32 room);
 void cur_obj_enable_rendering_if_mario_in_room(void);
 s32 cur_obj_set_hitbox_and_die_if_attacked(struct ObjectHitbox *hitbox, s32 deathSound, s32 noLootCoins);
 void obj_explode_and_spawn_coins(f32 mistSize, s32 coinType);

--- a/src/game/object_helpers.h
+++ b/src/game/object_helpers.h
@@ -235,7 +235,7 @@ void cur_obj_call_action_function(ObjActionFunc actionFunctions[]);
 s32 cur_obj_mario_far_away(void);
 s32 is_mario_moving_fast_or_in_air(s32 speedThreshold);
 s32 is_item_in_array(s8 item, s8 *array);
-u32 is_room_loaded(s32 room);
+u32 is_room_loaded(void);
 void cur_obj_enable_rendering_if_mario_in_room(void);
 s32 cur_obj_set_hitbox_and_die_if_attacked(struct ObjectHitbox *hitbox, s32 deathSound, s32 noLootCoins);
 void obj_explode_and_spawn_coins(f32 mistSize, s32 coinType);


### PR DESCRIPTION
* Object flag for forcing objects to always be loaded regardless of room
* Does nothing if the object doesn't call bhv_init_room