### PR TITLE
Bugfix: Reset Mario's room when switching areas

### DIFF
--- a/src/game/area.c
+++ b/src/game/area.c
@@ -235,6 +235,8 @@ void load_area(s32 index) {
         main_pool_pop_state();
         main_pool_push_state();
 
+        gMarioCurrentRoom = 0;
+
         if (gCurrentArea->terrainData != NULL) {
             load_area_terrain(index, gCurrentArea->terrainData, gCurrentArea->surfaceRooms,
                               gCurrentArea->macroObjects);


### PR DESCRIPTION
Mario's room sometimes is not reset when warping between different areas, generally when warping from one area with rooms to another without them. This can cause things like doors to not render properly.