### PR TITLE
Fix WF Stationary Platforms

### DIFF
--- a/data/behavior_data.c
+++ b/data/behavior_data.c
@@ -1679,9 +1679,9 @@ const BehaviorScript bhvWfSolidTowerPlatform[] = {
     BEGIN(OBJ_LIST_SURFACE),
     OR_INT(oFlags, (OBJ_FLAG_SET_FACE_YAW_TO_MOVE_YAW | OBJ_FLAG_UPDATE_GFX_POS_AND_ANGLE)),
     LOAD_COLLISION_DATA(wf_seg7_collision_platform),
-    CALL_NATIVE(load_object_static_model),
     BEGIN_LOOP(),
         CALL_NATIVE(bhv_wf_solid_tower_platform_loop),
+        CALL_NATIVE(load_object_collision_model),
     END_LOOP(),
 };
 


### PR DESCRIPTION
Whomp's Fortress stationary platforms were given static collision despite being able to delete themselves. This resulted in both a memory leak and stale object referencing that impacted Mario's positioning.