### PR TITLE
Bugfix: skyboxes access tiles out of range when looking straight down

### DIFF
--- a/src/game/skybox.c
+++ b/src/game/skybox.c
@@ -217,6 +217,10 @@ void draw_skybox_tile_grid(Gfx **dlist, s8 background, s8 player, s8 colorIndex)
     for (row = 0; row < (3 * SKYBOX_SIZE); row++) {
         for (col = 0; col < (3 * SKYBOX_SIZE); col++) {
             s32 tileIndex = sSkyBoxInfo[player].upperLeftTile + row * SKYBOX_COLS + col;
+            if (tileIndex >= SKYBOX_ROWS * SKYBOX_COLS) {
+                continue;
+            }
+
             const Texture *const texture =
                 (*(SkyboxTexture *) segmented_to_virtual(sSkyboxTextures[background]))[tileIndex];
             Vtx *vertices = make_skybox_rect(tileIndex, colorIndex);


### PR DESCRIPTION
It's really that simple.