### PR TITLE
Wrap boulder room check under vanilla specific level checks

### DIFF
--- a/src/game/behaviors/boulder.inc.c
+++ b/src/game/behaviors/boulder.inc.c
@@ -1,5 +1,4 @@
 // boulder.inc.c
-#include "config.h"
 
 void bhv_big_boulder_init(void) {
     vec3f_copy(&o->oHomeVec, &o->oPosVec);
@@ -53,6 +52,7 @@ void bhv_big_boulder_generator_loop(void) {
     if (o->oTimer >= 256) {
         o->oTimer = 0;
     }
+
 #ifdef ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
     if (!current_mario_room_check(4)
         || is_point_within_radius_of_mario(o->oPosX, o->oPosY, o->oPosZ, 1500)) {

--- a/src/game/behaviors/boulder.inc.c
+++ b/src/game/behaviors/boulder.inc.c
@@ -1,4 +1,5 @@
 // boulder.inc.c
+#include "config.h"
 
 void bhv_big_boulder_init(void) {
     vec3f_copy(&o->oHomeVec, &o->oPosVec);
@@ -52,11 +53,16 @@ void bhv_big_boulder_generator_loop(void) {
     if (o->oTimer >= 256) {
         o->oTimer = 0;
     }
-
+#ifdef ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
     if (!current_mario_room_check(4)
         || is_point_within_radius_of_mario(o->oPosX, o->oPosY, o->oPosZ, 1500)) {
         return;
     }
+#else 
+    if (is_point_within_radius_of_mario(o->oPosX, o->oPosY, o->oPosZ, 1500)) {
+        return;
+    }
+#endif
 
     if (is_point_within_radius_of_mario(o->oPosX, o->oPosY, o->oPosZ, 6000)) {
         if (!(o->oTimer & 0x3F)) {

--- a/src/game/behaviors/boulder.inc.c
+++ b/src/game/behaviors/boulder.inc.c
@@ -56,13 +56,11 @@ void bhv_big_boulder_generator_loop(void) {
 #ifdef ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
     if (!current_mario_room_check(4)
         || is_point_within_radius_of_mario(o->oPosX, o->oPosY, o->oPosZ, 1500)) {
-        return;
-    }
 #else 
     if (is_point_within_radius_of_mario(o->oPosX, o->oPosY, o->oPosZ, 1500)) {
+#endif
         return;
     }
-#endif
 
     if (is_point_within_radius_of_mario(o->oPosX, o->oPosY, o->oPosZ, 6000)) {
         if (!(o->oTimer & 0x3F)) {


### PR DESCRIPTION
In vanilla boulders only spawn if mario is in a specific room. This is now wrapped under `ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS`