### PR TITLE
Increase max number of concurrent layers and channels

### DIFF
--- a/src/audio/internal.h
+++ b/src/audio/internal.h
@@ -5,6 +5,16 @@
 
 #include "types.h"
 
+#ifdef EXPAND_AUDIO_HEAP // Not technically on the heap but it's memory nonetheless...
+#if defined(VERSION_EU) || defined(VERSION_SH)
+#define SEQUENCE_PLAYERS 4
+#define SEQUENCE_CHANNELS 64
+#else
+#define SEQUENCE_PLAYERS 3
+#define SEQUENCE_CHANNELS 48
+#endif
+#define SEQUENCE_LAYERS (SEQUENCE_CHANNELS * 2)
+#else // EXPAND_AUDIO_HEAP
 #if defined(VERSION_EU) || defined(VERSION_SH)
 #define SEQUENCE_PLAYERS 4
 #define SEQUENCE_CHANNELS 48
@@ -12,12 +22,9 @@
 #else
 #define SEQUENCE_PLAYERS 3
 #define SEQUENCE_CHANNELS 32
-#ifdef VERSION_JP
-#define SEQUENCE_LAYERS 48
-#else
 #define SEQUENCE_LAYERS 52
 #endif
-#endif
+#endif // EXPAND_AUDIO_HEAP
 
 #define LAYERS_MAX       4
 #define CHANNELS_MAX     16

--- a/src/audio/internal.h
+++ b/src/audio/internal.h
@@ -5,29 +5,27 @@
 
 #include "types.h"
 
-#ifdef EXPAND_AUDIO_HEAP // Not technically on the heap but it's memory nonetheless...
 #if defined(VERSION_EU) || defined(VERSION_SH)
 #define SEQUENCE_PLAYERS 4
-#define SEQUENCE_CHANNELS 64
 #else
 #define SEQUENCE_PLAYERS 3
-#define SEQUENCE_CHANNELS 48
 #endif
-#define SEQUENCE_LAYERS (SEQUENCE_CHANNELS * 2)
+
+#define LAYERS_MAX       4
+#define CHANNELS_MAX     16
+
+#ifdef EXPAND_AUDIO_HEAP // Not technically on the heap but it's memory nonetheless...
+#define SEQUENCE_CHANNELS (SEQUENCE_PLAYERS * CHANNELS_MAX)
+#define SEQUENCE_LAYERS ((SEQUENCE_CHANNELS * LAYERS_MAX) / 2) // This should be more than plenty in nearly all circumstances.
 #else // EXPAND_AUDIO_HEAP
 #if defined(VERSION_EU) || defined(VERSION_SH)
-#define SEQUENCE_PLAYERS 4
 #define SEQUENCE_CHANNELS 48
 #define SEQUENCE_LAYERS 64
 #else
-#define SEQUENCE_PLAYERS 3
 #define SEQUENCE_CHANNELS 32
 #define SEQUENCE_LAYERS 52
 #endif
 #endif // EXPAND_AUDIO_HEAP
-
-#define LAYERS_MAX       4
-#define CHANNELS_MAX     16
 
 #define NO_LAYER ((struct SequenceChannelLayer *)(-1))
 


### PR DESCRIPTION
At worst, this eats up a few KB of memory. Runtime difference should be negligible when the extra data is not being used. Primary advantage of this is not cutting off envplayer sequences that are even remotely complex.