### PR TITLE
Added safety gcc math flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ LINK_LIBRARIES = $(foreach i,$(LIBRARIES),-l$(i))
 
 # Default non-gcc opt flags
 DEFAULT_OPT_FLAGS = -Ofast
+SAFETY_OPT_FLAGS = -ftrapping-math -fno-associative-math -fno-unsafe-math-optimizations
 
 # Main opt flags
 GCC_MAIN_OPT_FLAGS = \
@@ -145,7 +146,8 @@ GCC_MAIN_OPT_FLAGS = \
   -finline-limit=1 \
   -freorder-blocks-algorithm=simple  \
   -ffunction-sections \
-  -fdata-sections
+  -fdata-sections \
+  $(SAFETY_OPT_FLAGS)
 
 # Surface Collision
 GCC_COLLISION_OPT_FLAGS = \
@@ -158,7 +160,8 @@ GCC_COLLISION_OPT_FLAGS = \
   -freorder-blocks-algorithm=simple  \
   -ffunction-sections \
   -fdata-sections \
-  -falign-functions=32
+  -falign-functions=32 \
+  $(SAFETY_OPT_FLAGS)
 
 # Math Util
 GCC_MATH_UTIL_OPT_FLAGS = \
@@ -168,7 +171,8 @@ GCC_MATH_UTIL_OPT_FLAGS = \
   --param case-values-threshold=20  \
   -ffunction-sections \
   -fdata-sections \
-  -falign-functions=32
+  -falign-functions=32 \
+  $(SAFETY_OPT_FLAGS)
 #   - setting any sort of -finline-limit has shown to worsen performance with math_util.c,
 #     lower values were the worst, the higher you go - the closer performance gets to not setting it at all
 
@@ -182,7 +186,8 @@ GCC_GRAPH_NODE_OPT_FLAGS = \
   -freorder-blocks-algorithm=simple  \
   -ffunction-sections \
   -fdata-sections \
-  -falign-functions=32
+  -falign-functions=32 \
+  $(SAFETY_OPT_FLAGS)
 #==============================================================================#
 
 ifeq ($(COMPILER),gcc)


### PR DESCRIPTION
These flags have been shown to prevent issues that are caused by `-ffast-math` on console