### PR TITLE
revert random_u16 to be a u16

### DIFF
--- a/src/engine/math_util.c
+++ b/src/engine/math_util.c
@@ -28,7 +28,7 @@ Vec3s gVec3sOne  = {     1,     1,     1 };
 static u16 gRandomSeed16;
 
 // Generate a pseudorandom integer from 0 to 65535 from the random seed, and update the seed.
-u32 random_u16(void) {
+u16 random_u16(void) {
     if (gRandomSeed16 == 22026) {
         gRandomSeed16 = 0;
     }

--- a/src/engine/math_util.h
+++ b/src/engine/math_util.h
@@ -475,7 +475,7 @@ ALWAYS_INLINE s32 absi(s32 in) {
 
 #define FLT_IS_NONZERO(x) (absf(x) > NEAR_ZERO)
 
-u32 random_u16(void);
+u16 random_u16(void);
 f32 random_float(void);
 s32 random_sign(void);
 


### PR DESCRIPTION
`random_u16` returning a `u32` can cause situations where the result is gigantic (even consistently). it should be reverted to be a `u16` again to prevent issues.

example:
`o->oPosX = (f32)((random_u16()/4)-8192);`
printing `o->oPosX` showed `4294964736.000000`
