### PR TITLE
HackerSM64 2.0.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ LINK_LIBRARIES = $(foreach i,$(LIBRARIES),-l$(i))
 
 # Default non-gcc opt flags
 DEFAULT_OPT_FLAGS = -Ofast
-SAFETY_OPT_FLAGS = -ftrapping-math -fno-associative-math -fno-unsafe-math-optimizations
+SAFETY_OPT_FLAGS = -ftrapping-math
 
 # Main opt flags
 GCC_MAIN_OPT_FLAGS = \

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ LINK_LIBRARIES = $(foreach i,$(LIBRARIES),-l$(i))
 
 # Default non-gcc opt flags
 DEFAULT_OPT_FLAGS = -Ofast
+SAFETY_OPT_FLAGS = -ftrapping-math -fno-associative-math -fno-unsafe-math-optimizations
 
 # Main opt flags
 GCC_MAIN_OPT_FLAGS = \
@@ -145,7 +146,8 @@ GCC_MAIN_OPT_FLAGS = \
   -finline-limit=1 \
   -freorder-blocks-algorithm=simple  \
   -ffunction-sections \
-  -fdata-sections
+  -fdata-sections \
+  $(SAFETY_OPT_FLAGS)
 
 # Surface Collision
 GCC_COLLISION_OPT_FLAGS = \
@@ -158,7 +160,8 @@ GCC_COLLISION_OPT_FLAGS = \
   -freorder-blocks-algorithm=simple  \
   -ffunction-sections \
   -fdata-sections \
-  -falign-functions=32
+  -falign-functions=32 \
+  $(SAFETY_OPT_FLAGS)
 
 # Math Util
 GCC_MATH_UTIL_OPT_FLAGS = \
@@ -168,7 +171,8 @@ GCC_MATH_UTIL_OPT_FLAGS = \
   --param case-values-threshold=20  \
   -ffunction-sections \
   -fdata-sections \
-  -falign-functions=32
+  -falign-functions=32 \
+  $(SAFETY_OPT_FLAGS)
 #   - setting any sort of -finline-limit has shown to worsen performance with math_util.c,
 #     lower values were the worst, the higher you go - the closer performance gets to not setting it at all
 
@@ -182,7 +186,8 @@ GCC_GRAPH_NODE_OPT_FLAGS = \
   -freorder-blocks-algorithm=simple  \
   -ffunction-sections \
   -fdata-sections \
-  -falign-functions=32
+  -falign-functions=32 \
+  $(SAFETY_OPT_FLAGS)
 #==============================================================================#
 
 ifeq ($(COMPILER),gcc)

--- a/src/engine/math_util.c
+++ b/src/engine/math_util.c
@@ -28,7 +28,7 @@ Vec3s gVec3sOne  = {     1,     1,     1 };
 static u16 gRandomSeed16;
 
 // Generate a pseudorandom integer from 0 to 65535 from the random seed, and update the seed.
-u32 random_u16(void) {
+u16 random_u16(void) {
     if (gRandomSeed16 == 22026) {
         gRandomSeed16 = 0;
     }

--- a/src/engine/math_util.h
+++ b/src/engine/math_util.h
@@ -475,7 +475,7 @@ ALWAYS_INLINE s32 absi(s32 in) {
 
 #define FLT_IS_NONZERO(x) (absf(x) > NEAR_ZERO)
 
-u32 random_u16(void);
+u16 random_u16(void);
 f32 random_float(void);
 s32 random_sign(void);
 


### PR DESCRIPTION
- revert `random_u16()` to be a u16
- Added safety gcc math flags

NOTE: Still needs updated version file