### PR TITLE
Bugfix: Stack sizes moved to `game/main.h`

### DIFF
--- a/src/buffers/buffers.h
+++ b/src/buffers/buffers.h
@@ -6,14 +6,8 @@
 
 #include "game/save_file.h"
 #include "game/game_init.h"
+#include "game/main.h"
 #include "config.h"
-
-#define THREAD1_STACK 0x100
-#define THREAD2_STACK 0x800
-#define THREAD3_STACK 0x200
-#define THREAD4_STACK 0x2000
-#define THREAD5_STACK 0x2000
-#define THREAD6_STACK 0x400
 
 extern u8 gDecompressionHeap[];
 

--- a/src/game/crash_screen.c
+++ b/src/game/crash_screen.c
@@ -11,7 +11,6 @@
 #include "main.h"
 #include "debug.h"
 #include "rumble_init.h"
-#include "buffers/buffers.h"
 
 #include "sm64.h"
 

--- a/src/game/main.h
+++ b/src/game/main.h
@@ -3,6 +3,13 @@
 
 #include "config.h"
 
+#define THREAD1_STACK 0x100
+#define THREAD2_STACK 0x800
+#define THREAD3_STACK 0x200
+#define THREAD4_STACK 0x2000
+#define THREAD5_STACK 0x2000
+#define THREAD6_STACK 0x400
+
 enum ThreadID {
     THREAD_0,
     THREAD_1_IDLE,


### PR DESCRIPTION
Crash screen does not enjoy importing `buffers/buffers.h`.