### PR TITLE
Start samples at full velocity when using envelopes that start with a delay of 1

### DIFF
--- a/src/audio/effects.c
+++ b/src/audio/effects.c
@@ -353,7 +353,9 @@ void adsr_init(struct AdsrState *adsr, struct AdsrEnvelope *envelope, UNUSED s16
 #if defined(VERSION_EU) || defined(VERSION_SH)
 f32 adsr_update(struct AdsrState *adsr) {
 #else
-s32 adsr_update(struct AdsrState *adsr) {
+s32 adsr_update(struct Note *note) {
+    struct AdsrState *adsr = &note->adsr;
+    u8 isInit = FALSE;
 #endif
     u8 action = adsr->action;
     u8 state = adsr->state;
@@ -362,6 +364,10 @@ s32 adsr_update(struct AdsrState *adsr) {
             return 0;
 
         case ADSR_STATE_INITIAL:
+            isInit = TRUE;
+            // fallthrough
+
+        case ADSR_STATE_RESTART:
 #if defined(VERSION_JP) || defined(VERSION_US)
             adsr->current = adsr->initial;
             adsr->target = adsr->initial;
@@ -401,7 +407,7 @@ s32 adsr_update(struct AdsrState *adsr) {
                     break;
 #endif
                 case ADSR_RESTART:
-                    adsr->state = ADSR_STATE_INITIAL;
+                    adsr->state = ADSR_STATE_RESTART;
                     break;
 
                 default:
@@ -422,6 +428,10 @@ s32 adsr_update(struct AdsrState *adsr) {
                     adsr->target = adsr->target * adsr->target;
                     adsr->velocity = (adsr->target - adsr->current) / adsr->delay;
 #else // !(VERSION_EU || VERSION_SH)
+                    if (isInit && adsr->delay <= 1) {
+                        note->initFullVelocity = TRUE;
+                    }
+
                     adsr->target = BSWAP16(adsr->envelope[adsr->envIndex].arg);
                     adsr->velocity = ((adsr->target - adsr->current) << 0x10) / adsr->delay;
 #endif // !(VERSION_EU || VERSION_SH)

--- a/src/audio/effects.h
+++ b/src/audio/effects.h
@@ -15,7 +15,8 @@ enum ADSRStates {
     ADSR_STATE_HANG,
     ADSR_STATE_DECAY,
     ADSR_STATE_RELEASE,
-    ADSR_STATE_SUSTAIN
+    ADSR_STATE_SUSTAIN,
+    ADSR_STATE_RESTART
 };
 
 enum ADSRActions {
@@ -52,7 +53,7 @@ void adsr_init(struct AdsrState *adsr, struct AdsrEnvelope *envelope, s16 *volOu
 #if defined(VERSION_EU) || defined(VERSION_SH)
 f32 adsr_update(struct AdsrState *adsr);
 #else
-s32 adsr_update(struct AdsrState *adsr);
+s32 adsr_update(struct Note *note);
 #endif
 
 #endif // AUDIO_EFFECTS_H

--- a/src/audio/internal.h
+++ b/src/audio/internal.h
@@ -662,15 +662,17 @@ struct vNote {
 }; // size = 0xC0
 struct Note {
     /* U/J, EU  */
-    /*0x00*/ u8 enabled              : 1;
-    /*0x00*/ u8 needsInit            : 1;
-    /*0x00*/ u8 restart              : 1;
-    /*0x00*/ u8 finished             : 1;
-    /*0x00*/ u8 envMixerNeedsInit    : 1;
-    /*0x00*/ u8 stereoStrongRight    : 1;
-    /*0x00*/ u8 stereoStrongLeft     : 1;
-    /*0x00*/ u8 stereoHeadsetEffects : 1;
-    /*0x01*/ u8 usesHeadsetPanEffects;
+    /*0x00*/ u8 enabled               : 1;
+    /*0x00*/ u8 needsInit             : 1;
+    /*0x00*/ u8 restart               : 1;
+    /*0x00*/ u8 finished              : 1;
+    /*0x00*/ u8 envMixerNeedsInit     : 1;
+    /*0x00*/ u8 stereoStrongRight     : 1;
+    /*0x00*/ u8 stereoStrongLeft      : 1;
+    /*0x00*/ u8 stereoHeadsetEffects  : 1;
+    /*0x01*/ u8 usesHeadsetPanEffects : 1;
+    /*0x01*/ u8 initFullVelocity      : 1;
+    /*    */ u8 pad0                  : 6;
     /*0x02*/ u8 unk2;
     /*0x03*/ u8 sampleDmaIndex;
     /*0x04, 0x30*/ u8 priority;

--- a/src/audio/playback.c
+++ b/src/audio/playback.c
@@ -578,7 +578,7 @@ void process_notes(void) {
                 }
             }
 
-            adsr_update(&note->adsr);
+            adsr_update(note);
             note_vibrato_update(note);
             attributes = &note->attributes;
             if (note->priority == NOTE_PRIORITY_STOPPING) {
@@ -1427,6 +1427,7 @@ void note_init_all(void) {
 #else
         note->reverbVol = 0;
         note->usesHeadsetPanEffects = FALSE;
+        note->initFullVelocity = FALSE;
         note->sampleCount = 0;
         note->instOrWave = 0;
         note->targetVolLeft = 0;

--- a/src/audio/synthesis.c
+++ b/src/audio/synthesis.c
@@ -1313,8 +1313,14 @@ u64 *final_resample(u64 *cmd, struct Note *note, s32 count, u16 pitch, u16 dmemI
 u64 *process_envelope(u64 *cmd, struct Note *note, s32 nSamples, u16 inBuf, s32 headsetPanSettings,
                       UNUSED u32 flags) {
     struct VolumeChange vol;
-    vol.sourceLeft = note->curVolLeft;
-    vol.sourceRight = note->curVolRight;
+    if (note->initFullVelocity) {
+        note->initFullVelocity = FALSE;
+        vol.sourceLeft = note->targetVolLeft;
+        vol.sourceRight = note->targetVolRight;
+    } else {
+        vol.sourceLeft = note->curVolLeft;
+        vol.sourceRight = note->curVolRight;
+    }
     vol.targetLeft = note->targetVolLeft;
     vol.targetRight = note->targetVolRight;
     note->curVolLeft = vol.targetLeft;
@@ -1650,6 +1656,7 @@ void note_enable(struct Note *note) {
     note->stereoStrongRight = FALSE;
     note->stereoStrongLeft = FALSE;
     note->usesHeadsetPanEffects = FALSE;
+    note->initFullVelocity = FALSE;
     note->headsetPanLeft = 0;
     note->headsetPanRight = 0;
     note->prevHeadsetPanRight = 0;

--- a/src/audio/synthesis.c
+++ b/src/audio/synthesis.c
@@ -986,7 +986,7 @@ u64 *synthesis_process_notes(s16 *aiBuf, s32 bufLen, u64 *cmd) {
                             s2 = 16;
                         }
 #else
-                        if (s2 == 0 && note->restart == FALSE) {
+                        if (s2 == 0 && note->restart == FALSE && flags != A_INIT) {
                             s2 = 16;
                         }
 #endif

--- a/src/audio/synthesis.c
+++ b/src/audio/synthesis.c
@@ -986,7 +986,7 @@ u64 *synthesis_process_notes(s16 *aiBuf, s32 bufLen, u64 *cmd) {
                             s2 = 16;
                         }
 #else
-                        if (s2 == 0 && note->restart == FALSE && flags != A_INIT) {
+                        if (s2 == 0 && note->restart == FALSE) {
                             s2 = 16;
                         }
 #endif
@@ -1087,7 +1087,12 @@ u64 *synthesis_process_notes(s16 *aiBuf, s32 bufLen, u64 *cmd) {
 
                         switch (flags) {
                             case A_INIT: // = 1
-                                sp130 = 0;
+                                /**
+                                 * !NOTE: Removing this seems to produce a more accurate waveform, however I have no idea why Nintendo decided to add this originally.
+                                 * I can only speculate (and hope) that this was just an oversight on their part and this has no reason to exist, given my testing.
+                                 * I'm leaving it commented out here just in case though.
+                                 */
+                                // sp130 = 0;
                                 s5 = s0 * 2 + s5;
                                 break;
 


### PR DESCRIPTION
This can help eliminate sample artifacting that happens during a transition between a sudden fade-in into normal volume. It's not completely eliminated due to some processing weirdness, but it's a massive improvement.