### PR TITLE
Bugfix: Fix Dynamic Collision Shadow Crash

### DIFF
--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -568,6 +568,8 @@ void load_area_terrain(s32 index, TerrainData *data, RoomData *surfaceRooms, s16
 void clear_dynamic_surfaces(void) {
     PUPPYPRINT_GET_SNAPSHOT();
     if (!(gTimeStopState & TIME_STOP_ACTIVE)) {
+        clear_dynamic_surface_references();
+
         gSurfacesAllocated = gNumStaticSurfaces;
         gSurfaceNodesAllocated = gNumStaticSurfaceNodes;
         gDynamicSurfacePoolEnd = gDynamicSurfacePool;

--- a/src/game/object_list_processor.c
+++ b/src/game/object_list_processor.c
@@ -617,6 +617,22 @@ UNUSED static u16 unused_get_elapsed_time(u64 *cycleCounts, s32 index) {
 }
 
 /**
+ * Clear all floors tied to dynamic collision, as they become invalid once the dynamic
+ * surfaces are cleared.
+ * 
+ * NOTE: Checking over the full object pool is slower than checking against the linked lists of active
+ * objects until the active object pool is around half capacity, after which, this is faster.
+ * Change this function to use a linked list instead if you add any additional logic here whatsoever.
+ */
+void clear_dynamic_surface_references(void) {
+    for (s32 i = 0; i < OBJECT_POOL_CAPACITY; i++) {
+        if (gObjectPool[i].oFloor && gObjectPool[i].oFloor->flags & SURFACE_FLAG_DYNAMIC) {
+            gObjectPool[i].oFloor = NULL;
+        }
+    }
+}
+
+/**
  * Update all objects. This includes script execution, object collision detection,
  * and object surface management.
  */

--- a/src/game/object_list_processor.h
+++ b/src/game/object_list_processor.h
@@ -141,6 +141,7 @@ void set_object_respawn_info_bits(struct Object *obj, u8 bits);
 void unload_objects_from_area(UNUSED s32 unused, s32 areaIndex);
 void spawn_objects_from_info(UNUSED s32 unused, struct SpawnInfo *spawnInfo);
 void clear_objects(void);
+void clear_dynamic_surface_references(void);
 void update_objects(UNUSED s32 unused);
 
 

--- a/src/game/spawn_object.c
+++ b/src/game/spawn_object.c
@@ -94,6 +94,7 @@ void clear_object_lists(struct ObjectNode *objLists) {
 void unload_object(struct Object *obj) {
     obj->activeFlags = ACTIVE_FLAG_DEACTIVATED;
     obj->prevObj = NULL;
+    obj->oFloor = NULL;
 
     obj->header.gfx.throwMatrix = NULL;
     stop_sounds_from_source(obj->header.gfx.cameraToObject);


### PR DESCRIPTION
Clear all references to every object's oFloor each frame when using with dynamic collision. This fixes the issues that presented themselves with the dynamic/static collision introduction. The issue itself was NOT introduced by the collision optimizations, rather it exposed the issue since the surface pool is now shared with the surface node pool, making it possible for entries to be misaligned.

Since object floors were not being cleared each frame while the dynamic collision was, it meant that old object floors would still be pointing to the former addresses of no longer existent collision. This didn't really cause problems beforehand since the stale references would always just end up pointing to a null object, a valid (but possibly incorrect) object, or at worst, a deallocated object. Now since surface nodes are stored in the pool with different sizes, the worst and common case is for the object to be represented as a non-pointer value, which means a crash.

Measured performance overhead to clear the floors each frame is about 160µs. Time loss from the removal of dynamic floor caching is unknown, but it doesn't really matter because it was never working anyway.