### PR TITLE
Allow envelopes with delay values of 0 on init

### DIFF
--- a/include/seq_macros.inc
+++ b/include/seq_macros.inc
@@ -684,7 +684,7 @@
 // envelope commands
 
 .macro envelope_disable a
-    .byte 0x0, 0x0
+    .byte 0xff, 0xfc
     .byte \a >> 8, \a & 0xff
 .endm
 

--- a/src/audio/effects.c
+++ b/src/audio/effects.c
@@ -428,8 +428,9 @@ s32 adsr_update(struct Note *note) {
                     adsr->target = adsr->target * adsr->target;
                     adsr->velocity = (adsr->target - adsr->current) / adsr->delay;
 #else // !(VERSION_EU || VERSION_SH)
-                    if (isInit && adsr->delay <= 1) {
-                        note->initFullVelocity = TRUE;
+                    if (adsr->delay <= 0) {
+                        adsr->delay = 1;
+                        note->initFullVelocity = isInit;
                     }
 
                     adsr->target = BSWAP16(adsr->envelope[adsr->envIndex].arg);

--- a/src/audio/effects.h
+++ b/src/audio/effects.h
@@ -26,10 +26,10 @@ enum ADSRActions {
 };
 
 enum ADSRDelays {
-    ADSR_DISABLE =  0,
     ADSR_HANG    = -1,
     ADSR_GOTO    = -2,
     ADSR_RESTART = -3,
+    ADSR_DISABLE = -4,
 };
 
 enum VibratoModes {

--- a/tools/assemble_sound.py
+++ b/tools/assemble_sound.py
@@ -341,10 +341,10 @@ def validate_bank(json, sample_bank):
                     last_fine = True
                 else:
                     validate_int_in_range(
-                        entry[0], 1, 2 ** 16 - 4, "envelope entry's first part"
+                        entry[0], 0, 2 ** 15 - 1, "envelope entry's first part"
                     )
                     validate_int_in_range(
-                        entry[1], 0, 2 ** 16 - 1, "envelope entry's second part"
+                        entry[1], 0, 2 ** 15 - 1, "envelope entry's second part"
                     )
                     last_fine = False
         validate(
@@ -589,7 +589,7 @@ def serialize_ctl(bank, base_ser, is_shindou):
         env_name_to_addr[name] = ser.size
         for entry in env:
             if entry == "stop":
-                entry = [0, 0]
+                entry = [2 ** 16 - 4, 0]
             elif entry == "hang":
                 entry = [2 ** 16 - 1, 0]
             elif entry == "restart":


### PR DESCRIPTION
This allows sounds to start instantly without any fade-in. Using new soundbanks with delay values of 0 will not compile with base decomp, but old decomp-compliant soundbanks will work with this commit.