### PR TITLE
condition that forces level reload on exit course

### DIFF
--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -428,9 +428,7 @@ void init_mario_after_warp(void) {
         }
 #endif
 #ifndef DISABLE_EXIT_COURSE
-       if (sWarpDest.levelNum == EXIT_COURSE_LEVEL && sWarpDest.areaIdx == EXIT_COURSE_AREA
-            && sWarpDest.nodeId == EXIT_COURSE_NODE
-        ) {
+       if (sWarpDest.arg == WARP_FLAG_EXIT_COURSE) {
             play_sound(SOUND_MENU_MARIO_CASTLE_WARP, gGlobalSoundSource);
         }
 #endif
@@ -608,7 +606,7 @@ s16 music_unchanged_through_warp(s16 arg) {
 void initiate_warp(s16 destLevel, s16 destArea, s16 destWarpNode, s32 warpFlags) {
     if (destWarpNode >= WARP_NODE_CREDITS_MIN) {
         sWarpDest.type = WARP_TYPE_CHANGE_LEVEL;
-    } else if (destLevel == EXIT_COURSE_LEVEL && destArea == EXIT_COURSE_AREA && destWarpNode == EXIT_COURSE_NODE) {
+    } else if (warpFlags == WARP_FLAG_EXIT_COURSE) {
         sWarpDest.type = WARP_TYPE_CHANGE_LEVEL;
     } else if (destLevel != gCurrLevelNum) {
         sWarpDest.type = WARP_TYPE_CHANGE_LEVEL;
@@ -1071,7 +1069,7 @@ s32 play_mode_paused(void) {
         if (gDebugLevelSelect) {
             fade_into_special_warp(WARP_SPECIAL_LEVEL_SELECT, 1);
         } else {
-            initiate_warp(EXIT_COURSE_LEVEL, EXIT_COURSE_AREA, EXIT_COURSE_NODE, WARP_FLAGS_NONE);
+            initiate_warp(EXIT_COURSE_LEVEL, EXIT_COURSE_AREA, EXIT_COURSE_NODE, WARP_FLAG_EXIT_COURSE);
             fade_into_special_warp(WARP_SPECIAL_NONE, 0);
             gSavedCourseNum = COURSE_NONE;
         }

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -608,6 +608,8 @@ s16 music_unchanged_through_warp(s16 arg) {
 void initiate_warp(s16 destLevel, s16 destArea, s16 destWarpNode, s32 warpFlags) {
     if (destWarpNode >= WARP_NODE_CREDITS_MIN) {
         sWarpDest.type = WARP_TYPE_CHANGE_LEVEL;
+    } else if (destLevel == EXIT_COURSE_LEVEL && destArea == EXIT_COURSE_AREA && destWarpNode == EXIT_COURSE_NODE) {
+        sWarpDest.type = WARP_TYPE_CHANGE_LEVEL;
     } else if (destLevel != gCurrLevelNum) {
         sWarpDest.type = WARP_TYPE_CHANGE_LEVEL;
     } else if (destArea != gCurrentArea->index) {

--- a/src/game/level_update.h
+++ b/src/game/level_update.h
@@ -40,11 +40,12 @@ enum SpecialWarpDestinations {
     WARP_SPECIAL_NONE                =  0,
 };
 
-enum WarpDoorFlags {
+enum WarpFlags {
     WARP_FLAGS_NONE           = (0 << 0), // 0x00
     WARP_FLAG_DOOR_PULLED     = (1 << 0), // 0x01
     WARP_FLAG_DOOR_FLIP_MARIO = (1 << 1), // 0x02
     WARP_FLAG_DOOR_IS_WARP    = (1 << 2), // 0x04
+    WARP_FLAG_EXIT_COURSE     = (1 << 3), // 0x08
 };
 
 enum MarioSpawnType {


### PR DESCRIPTION
Fixes the crash that happens when you exit course warp into the same level you're in. The fix is surprisingly simple, it just forces a level reload always when exiting course, which should be how it works anyways when you exit course into the same level.