### PR TITLE
Remove decompression heap function

### DIFF
--- a/src/boot/memory.c
+++ b/src/boot/memory.c
@@ -419,42 +419,6 @@ void *load_segment_decompress(s32 segment, u8 *srcStart, u8 *srcEnd) {
     return dest;
 }
 
-void *load_segment_decompress_heap(u32 segment, u8 *srcStart, u8 *srcEnd) {
-    UNUSED void *dest = NULL;
-
-#ifdef GZIP
-    u32 compSize = (srcEnd - 4 - srcStart);
-#else
-    u32 compSize = ALIGN16(srcEnd - srcStart);
-#endif
-    u8 *compressed = main_pool_alloc(compSize, MEMORY_POOL_RIGHT);
-#ifdef GZIP
-    // Decompressed size from end of gzip
-    u32 *size = (u32 *) (compressed + compSize);
-#endif
-    if (compressed != NULL) {
-#ifdef UNCOMPRESSED
-        dma_read(gDecompressionHeap, srcStart, srcEnd);
-#else
-        dma_read(compressed, srcStart, srcEnd);
-#endif
-#ifdef GZIP
-        expand_gzip(compressed, gDecompressionHeap, compSize, (u32)size);
-#elif RNC1
-        Propack_UnpackM1(compressed, gDecompressionHeap);
-#elif RNC2
-        Propack_UnpackM2(compressed, gDecompressionHeap);
-#elif YAY0
-        slidstart(compressed, gDecompressionHeap);
-#elif MIO0
-        decompress(compressed, gDecompressionHeap);
-#endif
-        set_segment_base_addr(segment, gDecompressionHeap);
-        main_pool_free(compressed);
-    }
-    return gDecompressionHeap;
-}
-
 void load_engine_code_segment(void) {
     void *startAddr = (void *) _engineSegmentStart;
     u32 totalSize = _engineSegmentEnd - _engineSegmentStart;

--- a/src/buffers/buffers.c
+++ b/src/buffers/buffers.c
@@ -9,7 +9,6 @@
 #include "config.h"
 #include "audio/synthesis.h"
 
-ALIGNED8 u8 gDecompressionHeap[0xD000];
 ALIGNED16 u8 gAudioHeap[DOUBLE_SIZE_ON_64_BIT(AUDIO_HEAP_SIZE)];
 
 ALIGNED8 u8 gIdleThreadStack[THREAD1_STACK];

--- a/src/buffers/buffers.h
+++ b/src/buffers/buffers.h
@@ -10,8 +10,6 @@
 #include "config.h"
 #include "audio/data.h"
 
-extern u8 gDecompressionHeap[];
-
 extern u8 gAudioHeap[DOUBLE_SIZE_ON_64_BIT(AUDIO_HEAP_SIZE)];
 
 extern u8 gIdleThreadStack[THREAD1_STACK];

--- a/src/engine/level_script.c
+++ b/src/engine/level_script.c
@@ -309,7 +309,7 @@ static void level_cmd_load_mario_head(void) {
 }
 
 static void level_cmd_load_yay0_texture(void) {
-    load_segment_decompress_heap(CMD_GET(s16, 2), CMD_GET(void *, 4), CMD_GET(void *, 8));
+    load_segment_decompress(CMD_GET(s16, 2), CMD_GET(void *, 4), CMD_GET(void *, 8));
     sCurrentCmd = CMD_NEXT;
 }
 

--- a/src/game/memory.h
+++ b/src/game/memory.h
@@ -60,13 +60,11 @@ u32 main_pool_pop_state(void);
 void *load_segment(s32 segment, u8 *srcStart, u8 *srcEnd, u32 side, u8 *bssStart, u8 *bssEnd);
 void *load_to_fixed_pool_addr(u8 *destAddr, u8 *srcStart, u8 *srcEnd);
 void *load_segment_decompress(s32 segment, u8 *srcStart, u8 *srcEnd);
-void *load_segment_decompress_heap(u32 segment, u8 *srcStart, u8 *srcEnd);
 void load_engine_code_segment(void);
 #else
 #define load_segment(...)
 #define load_to_fixed_pool_addr(...)
 #define load_segment_decompress(...)
-#define load_segment_decompress_heap(...)
 #define load_engine_code_segment(...)
 #endif
 


### PR DESCRIPTION
This function exists solely to waste 0xD000 bytes of RAM. Changing the calls to regular decompression calls has no functional difference.