### PR TITLE
Instant Input 2.0 draft

### DIFF
--- a/src/game/crash_screen.c
+++ b/src/game/crash_screen.c
@@ -11,6 +11,7 @@
 #include "main.h"
 #include "debug.h"
 #include "rumble_init.h"
+#include "instant_input.h"
 
 #include "sm64.h"
 
@@ -372,6 +373,7 @@ void draw_crash_screen(OSThread *thread) {
         osWritebackDCacheAll();
         osViBlack(FALSE);
         osViSwapBuffer(gCrashScreen.framebuffer);
+        if (USE_INSTANT_INPUT) __osViSwapContext();
         updateBuffer = FALSE;
     }
 }

--- a/src/game/instant_input.h
+++ b/src/game/instant_input.h
@@ -1,0 +1,10 @@
+#ifndef USE_INSTANT_INPUT
+
+#include "emutest.h"
+
+// TODO: Need to test if this still needs to be disabled on Simple64 and cen64. It seems to work fine, but might only break under more intensive graphics usage
+#define USE_INSTANT_INPUT (!(gEmulator & (EMU_CONSOLE | EMU_WIIVC | EMU_ARES | EMU_SIMPLE64 | EMU_CEN64 )))
+
+extern void __osViSwapContext(void);
+
+#endif

--- a/src/goddard/renderer.c
+++ b/src/goddard/renderer.c
@@ -18,6 +18,7 @@
 #include "shape_helper.h"
 #include "skin.h"
 #include "types.h"
+#include "game/instant_input.h"
 
 #define MAX_GD_DLS 1000
 #define OS_MESG_SI_COMPLETE 0x33333333
@@ -2019,6 +2020,7 @@ UNUSED static void func_801A01EC(void) {
 UNUSED static void func_801A025C(void) {
     gGdFrameBufNum ^= 1;
     osViSwapBuffer(sScreenView->parent->colourBufs[gGdFrameBufNum]);
+    if (USE_INSTANT_INPUT) __osViSwapContext();
 }
 
 /* 24EA88 -> 24EAF4 */

--- a/src/hvqm/hvqm.c
+++ b/src/hvqm/hvqm.c
@@ -5,6 +5,7 @@
 #include <hvqm2dec.h>
 #include <adpcmdec.h>
 #include "hvqm.h"
+#include "game/instant_input.h"
 
 #define AUDIO_DMA_MSG_SIZE 1
 static OSIoMesg     audioDmaMesgBlock;
@@ -124,6 +125,7 @@ void hvqm_main_proc() {
 
     init_cfb();
     osViSwapBuffer( gFramebuffers[NUM_CFBs-1] );
+    if (USE_INSTANT_INPUT) __osViSwapContext();
 
     romcpy(hvqm_header, (void *)_capcomSegmentRomStart, sizeof(HVQM2Header), OS_MESG_PRI_NORMAL, &videoDmaMesgBlock, &videoDmaMessageQ);
 

--- a/src/hvqm/timekeeper.c
+++ b/src/hvqm/timekeeper.c
@@ -3,6 +3,7 @@
 #include "hvqm.h"
 #include "audio/data.h"
 #include "buffers/framebuffers.h"
+#include "game/instant_input.h"
 
 /***********************************************************************
  * Timekeeper thread
@@ -327,6 +328,7 @@ static void timekeeperProc(void UNUSED*argument) {
 	    pushed_cfb_statP = videoRing[videoRingRead].statP;
 	    *pushed_cfb_statP |= CFB_SHOWING;
 	    osViSwapBuffer( pushed_cfb );
+	    if (USE_INSTANT_INPUT) __osViSwapContext();
 	    if ( ++videoRingRead == VIDEO_RING_SIZE ) videoRingRead = 0;
 	    --videoRingCount;
 	  }


### PR DESCRIPTION
Draft PR for better instant input. I still need to do testing before un-drafting it.

Things to test:
- Verify that it is actually still improving input delay as well as the previous patch
- Check if we still need to blacklist all of Ares, Simple64, and Cen64 or not
- Verify that the behaviour of the instant input patch when doing heavy framebuffer manipulation is better than before
- Verify that it fails more gracefully than the previous patch when run on console