### PR TITLE
Important Culling Fixes

### DIFF
--- a/include/config/config_graphics.h
+++ b/include/config/config_graphics.h
@@ -141,9 +141,10 @@
 // #define HORIZONTAL_CULLING_ON_EMULATOR
 
 /**
- * Makes objects bellow the screen be culled.
+ * Makes objects bellow the screen be culled. 
+ * NOTE: Vanilla objects do not account for vertical culling.
  */
-#define VERTICAL_CULLING
+// #define VERTICAL_CULLING
 
 /**
  * If the first command of an object´s geolayout is not GEO_CULLING_RADIUS, DEFAULT_CULLING_RADIUS

--- a/include/config/config_graphics.h
+++ b/include/config/config_graphics.h
@@ -137,7 +137,7 @@
 
 /**
  * May break viewport widescreen hacks.
- * When this is disabled,the culling will only be skipped according to the NO_CULLING_EMULATOR_BLACKLIST
+ * When this is disabled, the culling will only be skipped according to the NO_CULLING_EMULATOR_BLACKLIST.
  */
 // #define CULLING_ON_EMULATOR
 

--- a/include/config/config_graphics.h
+++ b/include/config/config_graphics.h
@@ -136,12 +136,13 @@
 
 
 /**
- * Limits the horizontal fov on emulator like on console. May break viewport widescreen hacks.
+ * May break viewport widescreen hacks.
+ * When this is disabled,the culling will only be skipped according to the NO_CULLING_EMULATOR_BLACKLIST
  */
 // #define CULLING_ON_EMULATOR
 
 /**
- * Makes objects bellow the screen be culled. 
+ * Makes objects below the screen be culled. 
  * NOTE: Vanilla objects do not account for vertical culling.
  */
 // #define VERTICAL_CULLING

--- a/include/config/config_graphics.h
+++ b/include/config/config_graphics.h
@@ -138,7 +138,7 @@
 /**
  * Limits the horizontal fov on emulator like on console. May break viewport widescreen hacks.
  */
-// #define HORIZONTAL_CULLING_ON_EMULATOR
+// #define CULLING_ON_EMULATOR
 
 /**
  * Makes objects bellow the screen be culled. 

--- a/src/game/rendering_graph_node.c
+++ b/src/game/rendering_graph_node.c
@@ -1057,6 +1057,9 @@ void geo_process_shadow(struct GraphNodeShadow *node) {
  *
  * Since (0,0,0) is unaffected by rotation, columns 0, 1 and 2 are ignored.
  */
+
+#define NO_CULLING_EMULATOR_BLACKLIST (EMU_CONSOLE | EMU_WIIVC | EMU_ARES | EMU_SIMPLE64 | EMU_CEN64)
+
 s32 obj_is_in_view(struct GraphNodeObject *node) {
     struct GraphNode *geo = node->sharedChild;
 
@@ -1081,10 +1084,9 @@ s32 obj_is_in_view(struct GraphNodeObject *node) {
         return FALSE;
     }
 
-#ifndef HORIZONTAL_CULLING_ON_EMULATOR
+#ifndef CULLING_ON_EMULATOR
     // If an emulator is detected, skip any other culling.
-
-    if(!(gEmulator & EMU_CONSOLE)){
+    if(!(gEmulator & NO_CULLING_EMULATOR_BLACKLIST)){
         return TRUE;
     }
 #endif


### PR DESCRIPTION
Precison of half fov horizontal being equal to or above 2 leads to many issues. using 1.5 would break rt64 and other emulators with ultra widescreen.
Vertical culling will be disabled by default until 3.0