### PR TITLE
Look for shared baserom directory using XDG_DATA_DIR instead of polluting the home directory

### DIFF
--- a/extract_assets.py
+++ b/extract_assets.py
@@ -4,7 +4,8 @@ import os
 import json
 import subprocess
 
-ROMS_DIR=os.path.expanduser("~/baseroms/")
+XDG_DATA_DIR=os.environ.get("XDG_DATA_HOME") or "~/.local/share"
+ROMS_DIR=os.path.expanduser(os.path.join(XDG_DATA_DIR, "HackerSM64"))
 
 sha1_LUT = {
     "eu": "4ac5721683d0e0b6bbb561b58a71740845dceea9",


### PR DESCRIPTION
A long time ago, people used to put all their application data in hidden directories in the home directory. This was very annoying because you would end up with tons of folders in your home directory. And so, the basedir-spec freedesktop specification was made to define where applications should store their user data, and everyone switched to using that. HackerSM64 should do the same.

The specification: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
Simplification from the Arch Linux wiki: https://wiki.archlinux.org/title/XDG_Base_Directory

tl;dr: don't pollute the home directory. Look for the baserom (and any other future things we want to persist across checkouts) in `$XDG_DATA_HOME/HackerSM64` (fallback to `~/.local/share/HackerSM64` if `XDG_DATA_HOME` is empty or not defined) instead of in a new directory in home.