### PR TITLE
Add functional changes to inertia to support only specific directions specified in the config

### DIFF
--- a/include/config/config_movement.h
+++ b/include/config/config_movement.h
@@ -74,11 +74,6 @@
 // #define PREVENT_CAP_LOSS
 
 /**
- * Enables Platform Displacement 2, also known as momentum patch. Makes Mario keep the momemtum from moving platforms.
- */
-#define PLATFORM_DISPLACEMENT_2
-
-/**
  * Uses Shindou's pole behavior.
  */
 // #define SHINDOU_POLES
@@ -135,4 +130,20 @@
  * Uncomment this to fix this bug, and frustrate speedrunners
  */
 // #define BUGFIX_DIALOG_TIME_STOP
+
+/**
+ * Enables Platform Displacement 2 // TODO: add more decription here
+ */
+#define PLATFORM_DISPLACEMENT_2
+
+#define INERTIA_NONE             0
+#define INERTIA_UPWARD           (1 << 0)
+#define INERTIA_DOWNWARD         (1 << 1)
+#define INERTIA_LEFT_RIGHT       (1 << 2)
+#define INERTIA_FORWARD_BACKWARD (1 << 3)
+
+/**
+ * Makes Mario keep momemtum when leaving moving platforms. Requires PLATFORM_DISPLACEMENT_2 to be enabled.
+ */
+#define MARIO_INERTIA (INERTIA_UPWARD | INERTIA_FORWARD_BACKWARD)
 

--- a/include/config/config_movement.h
+++ b/include/config/config_movement.h
@@ -132,13 +132,13 @@
 // #define BUGFIX_DIALOG_TIME_STOP
 
 /**
- * Enables Platform Displacement 2 // TODO: add more decription here
+ * Enables Platform Displacement 2, an upgrade to the physics involving moving platforms and how Mario interacts with them.
  */
 #define PLATFORM_DISPLACEMENT_2
 
 /**
  * Momentum defines; allow Mario to preserve his momemtum when leaving moving platforms.
- * Requires PLATFORM_DISPLACEMENT_2 to be enabled.
+ * These require Platform Displacement 2 to be enabled.
  */
 #define MARIO_INERTIA_UPWARD
 // #define MARIO_INERTIA_LATERAL

--- a/include/config/config_movement.h
+++ b/include/config/config_movement.h
@@ -136,14 +136,9 @@
  */
 #define PLATFORM_DISPLACEMENT_2
 
-#define INERTIA_NONE             0
-#define INERTIA_UPWARD           (1 << 0)
-#define INERTIA_DOWNWARD         (1 << 1)
-#define INERTIA_LEFT_RIGHT       (1 << 2)
-#define INERTIA_FORWARD_BACKWARD (1 << 3)
-
 /**
- * Makes Mario keep momemtum when leaving moving platforms. Requires PLATFORM_DISPLACEMENT_2 to be enabled.
+ * Momentum defines; allow Mario to preserve his momemtum when leaving moving platforms.
+ * Requires PLATFORM_DISPLACEMENT_2 to be enabled.
  */
-#define MARIO_INERTIA (INERTIA_UPWARD | INERTIA_FORWARD_BACKWARD)
-
+#define MARIO_INERTIA_UPWARD
+// #define MARIO_INERTIA_LATERAL

--- a/include/config/config_movement.h
+++ b/include/config/config_movement.h
@@ -137,7 +137,7 @@
 #define PLATFORM_DISPLACEMENT_2
 
 /**
- * Momentum defines; allow Mario to preserve his momemtum when leaving moving platforms.
+ * Inertia defines; allow Mario to preserve his momemtum when leaving moving platforms.
  * These require Platform Displacement 2 to be enabled.
  */
 #define MARIO_INERTIA_UPWARD

--- a/include/config/config_safeguards.h
+++ b/include/config/config_safeguards.h
@@ -181,18 +181,6 @@
 
 
 /*****************
- * config_movement.h
- */
-
-#ifndef PLATFORM_DISPLACEMENT_2
-    #undef MARIO_INERTIA
-#endif
-#ifndef MARIO_INERTIA
-    #define MARIO_INERTIA (INERTIA_NONE)
-#endif
-
-
-/*****************
  * config_objects.h
  */
 

--- a/include/config/config_safeguards.h
+++ b/include/config/config_safeguards.h
@@ -181,6 +181,18 @@
 
 
 /*****************
+ * config_movement.h
+ */
+
+#ifndef PLATFORM_DISPLACEMENT_2
+    #undef MARIO_INERTIA
+#endif
+#ifndef MARIO_INERTIA
+    #define MARIO_INERTIA (INERTIA_NONE)
+#endif
+
+
+/*****************
  * config_objects.h
  */
 

--- a/src/game/platform_displacement.c
+++ b/src/game/platform_displacement.c
@@ -181,9 +181,35 @@ static u8 sInertiaFirstFrame = FALSE;
 static void apply_mario_inertia(void) {
     // On the first frame of leaving the ground, boost Mario's y velocity
     if (sInertiaFirstFrame) {
+
+// Vertical Inertia
+#if ((MARIO_INERTIA & INERTIA_UPWARD) && (MARIO_INERTIA & INERTIA_DOWNWARD))
         gMarioState->vel[1] += sMarioAmountDisplaced[1];
+#elif (MARIO_INERTIA & INERTIA_UPWARD)
+        if (sMarioAmountDisplaced[1] > 0.0f) {
+            gMarioState->vel[1] += sMarioAmountDisplaced[1];
+        }
+#elif (MARIO_INERTIA & INERTIA_DOWNWARD)
+        if (sMarioAmountDisplaced[1] < 0.0f) {
+            gMarioState->vel[1] += sMarioAmountDisplaced[1];
+        }
+#endif
+
+// Horizontal Inertia
+#if (!((MARIO_INERTIA & INERTIA_LEFT_RIGHT) || (MARIO_INERTIA & INERTIA_FORWARD_BACKWARD)))
+        sMarioAmountDisplaced[0] = 0.0f;
+        sMarioAmountDisplaced[2] = 0.0f;
+#elif (!(MARIO_INERTIA & INERTIA_LEFT_RIGHT))
+        sMarioAmountDisplaced[0] *= ABS(sins(gMarioState->faceAngle[1]));
+        sMarioAmountDisplaced[2] *= ABS(coss(gMarioState->faceAngle[1]));
+#elif (!(MARIO_INERTIA & INERTIA_FORWARD_BACKWARD))
+        sMarioAmountDisplaced[2] *= ABS(sins(gMarioState->faceAngle[1]));
+        sMarioAmountDisplaced[0] *= ABS(coss(gMarioState->faceAngle[1]));
+#endif
     }
 
+// Apply Horizontal Inertia
+#if ((MARIO_INERTIA & INERTIA_LEFT_RIGHT) || (MARIO_INERTIA & INERTIA_FORWARD_BACKWARD))
     // Apply sideways inertia
     gMarioState->pos[0] += sMarioAmountDisplaced[0];
     gMarioState->pos[2] += sMarioAmountDisplaced[2];
@@ -191,6 +217,7 @@ static void apply_mario_inertia(void) {
     // Drag
     sMarioAmountDisplaced[0] *= 0.97f;
     sMarioAmountDisplaced[2] *= 0.97f;
+#endif
 
     // Stop applying inertia once Mario has landed, or when ground pounding
     if (!(gMarioState->action & ACT_FLAG_AIR) || (gMarioState->action == ACT_GROUND_POUND)) {

--- a/src/game/platform_displacement.c
+++ b/src/game/platform_displacement.c
@@ -180,7 +180,6 @@ static u8 sInertiaFirstFrame = FALSE;
  */
 static void apply_mario_inertia(void) {
 #ifdef MARIO_INERTIA_UPWARD
-    // Vertical Inertia
     // On the first frame of leaving the ground, boost Mario's y velocity
     if (sInertiaFirstFrame) {
         if (sMarioAmountDisplaced[1] > 0.0f) {

--- a/src/game/platform_displacement.c
+++ b/src/game/platform_displacement.c
@@ -179,37 +179,17 @@ static u8 sInertiaFirstFrame = FALSE;
  * Apply inertia based on Mario's last platform.
  */
 static void apply_mario_inertia(void) {
+#ifdef MARIO_INERTIA_UPWARD
+    // Vertical Inertia
     // On the first frame of leaving the ground, boost Mario's y velocity
     if (sInertiaFirstFrame) {
-
-// Vertical Inertia
-#if ((MARIO_INERTIA & INERTIA_UPWARD) && (MARIO_INERTIA & INERTIA_DOWNWARD))
-        gMarioState->vel[1] += sMarioAmountDisplaced[1];
-#elif (MARIO_INERTIA & INERTIA_UPWARD)
         if (sMarioAmountDisplaced[1] > 0.0f) {
             gMarioState->vel[1] += sMarioAmountDisplaced[1];
         }
-#elif (MARIO_INERTIA & INERTIA_DOWNWARD)
-        if (sMarioAmountDisplaced[1] < 0.0f) {
-            gMarioState->vel[1] += sMarioAmountDisplaced[1];
-        }
-#endif
-
-// Horizontal Inertia
-#if (!((MARIO_INERTIA & INERTIA_LEFT_RIGHT) || (MARIO_INERTIA & INERTIA_FORWARD_BACKWARD)))
-        sMarioAmountDisplaced[0] = 0.0f;
-        sMarioAmountDisplaced[2] = 0.0f;
-#elif (!(MARIO_INERTIA & INERTIA_LEFT_RIGHT))
-        sMarioAmountDisplaced[0] *= ABS(sins(gMarioState->faceAngle[1]));
-        sMarioAmountDisplaced[2] *= ABS(coss(gMarioState->faceAngle[1]));
-#elif (!(MARIO_INERTIA & INERTIA_FORWARD_BACKWARD))
-        sMarioAmountDisplaced[2] *= ABS(sins(gMarioState->faceAngle[1]));
-        sMarioAmountDisplaced[0] *= ABS(coss(gMarioState->faceAngle[1]));
-#endif
     }
+#endif
 
-// Apply Horizontal Inertia
-#if ((MARIO_INERTIA & INERTIA_LEFT_RIGHT) || (MARIO_INERTIA & INERTIA_FORWARD_BACKWARD))
+#ifdef MARIO_INERTIA_LATERAL
     // Apply sideways inertia
     gMarioState->pos[0] += sMarioAmountDisplaced[0];
     gMarioState->pos[2] += sMarioAmountDisplaced[2];


### PR DESCRIPTION
Still needs cleanup and additional opinions, marking as draft.

• What is the best approach in terms of enums for these? The config files can't actually use enums, so the solution is either to use defines as I am here or put the enum (and define) somewhere else, or change how the movement config is included everywhere.
• Somebody other than me please create a description for what Platform Displacement 2 actually does
• Do we want to add support for separating forwards and backwards momentum? If so, that means even more messy if checks. :(