### PR TITLE
restore mips-n64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,6 +407,8 @@ DEP_FILES := $(O_FILES:.o=.d) $(LIBZ_O_FILES:.o=.d) $(GODDARD_O_FILES:.o=.d) $(B
 # detect prefix for MIPS toolchain
 ifneq ($(call find-command,mips64-elf-ld),)
   CROSS := mips64-elf-
+else ifneq ($(call find-command,mips-n64-ld),)
+  CROSS := mips-n64-
 else ifneq ($(call find-command,mips64-ld),)
   CROSS := mips64-
 else ifneq ($(call find-command,mips-linux-gnu-ld),)


### PR DESCRIPTION
was accidentally removed by wiseguy for testing. can be up to a 2ms difference in performance so should be set as default. any sort of overrides can be done in another PR