### PR TITLE
only set rooms while in a new room

### DIFF
--- a/src/game/object_helpers.c
+++ b/src/game/object_helpers.c
@@ -129,10 +129,10 @@ Gfx *geo_switch_area(s32 callContext, struct GraphNode *node, UNUSED void *conte
             gMarioObject->oPosZ
         );
 
-        gMarioCurrentRoom = room;
         print_debug_top_down_objectinfo("areainfo %d", room);
 
         if (room > 0) {
+            gMarioCurrentRoom = room;
             switchCase->selectedCase = (room - 1);
         }
     } else {


### PR DESCRIPTION
if you stand on the floor in front of the checker tile towards the DDD painting and look back at the star door, you can see it disappear because you're technically in a different room. Room 0 is _supposed_ to be a non-room, and just preserve the room you're in. This fixes surface objects in rooms in general because that little piece of floor is the DDD painting.