### PR TITLE
removed extraneous mat stack index decrement in geo_process_camera

### DIFF
--- a/src/game/rendering_graph_node.c
+++ b/src/game/rendering_graph_node.c
@@ -47,7 +47,7 @@
  *
  */
 
-s16 gMatStackIndex;
+s16 gMatStackIndex = 0;
 ALIGNED16 Mat4 gMatStack[32];
 ALIGNED16 Mtx *gMatStackFixed[32];
 f32 sAspectRatio;
@@ -722,7 +722,6 @@ void geo_process_camera(struct GraphNodeCamera *node) {
         geo_process_node_and_siblings(node->fnNode.node.children);
         gCurGraphNodeCamera = NULL;
     }
-    gMatStackIndex--;
 }
 
 /**


### PR DESCRIPTION
sidenote it wont change anything, but I also initialized `gMatStackIndex` to 0.

Quick summary of the issue:

bekzii reported a fatal crash in PJ64 3.0.1. I confirmed it was easily replicable in PJ64 4.0. After some investigation, we found that the address of a matrix was the float value of 4/3, the aspect ratio.

![image](https://github.com/HackerN64/HackerSM64/assets/79979276/0a20e3bb-eb08-4f3a-a06d-c5d25e947278)
![image](https://github.com/HackerN64/HackerSM64/assets/79979276/1bac27b2-c254-4997-a266-4f82b20bb4b7)

`gMatStackIndex` was getting decremented too many times. This is due to `geo_process_camera` no longer pushing a camera relative matrix onto the top of the stack, and the old code not getting removed/updated after these changes. Once the "camera" processed the sm64 logo, the mat stack index was getting set to -1, so when accessing that matrix, it was showing the value of the address at `gMatStackIndex`. Now the reason why this only crashes on PJ64 is due to inaccurate RSP behavior, and throwing an error when the address exceeds an arbitrary value instead of wrapping it like console/other emulators. 

https://github.com/project64/project64/blob/2caa457d0261dc00370cf91e0c261b441f66dcc3/Source/Project64-rsp-core/cpu/RspDma.cpp#L22

So while this was discovered by yet another PJ64 inaccuracy, the issue it surfaced was valid.