### PR TITLE
Update Dockerfile to Ubuntu 22.04 as 18.04 is EOL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN mkdir /hackersm64
 WORKDIR /hackersm64
 ENV PATH="/hackersm64/tools:${PATH}"
 
-CMD echo 'Usage: docker run --rm --mount type=bind,source="$(pwd)",destination=/hackersm64 hackersm64 make VERSION=us -j4\n' \
+CMD echo 'Usage: docker run --rm -v ${PWD}:/hackersm64 hackersm64 make VERSION=us -j4\n' \
          'See https://github.com/HackerN64/HackerSM64/blob/master/README.md for more information'

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && \
         binutils-mips-linux-gnu \
         bsdextrautils \
         build-essential \
+        gcc-mips-linux-gnu \
         libcapstone-dev \
         pkgconf \
         python3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM ubuntu:18.04 as build
+FROM ubuntu:22.04 as build
 
 RUN apt-get update && \
     apt-get install -y \
         binutils-mips-linux-gnu \
-        bsdmainutils \
+        bsdextrautils \
         build-essential \
         libcapstone-dev \
         pkgconf \
         python3
 
-RUN mkdir /sm64
-WORKDIR /sm64
-ENV PATH="/sm64/tools:${PATH}"
+RUN mkdir /hackersm64
+WORKDIR /hackersm64
+ENV PATH="/hackersm64/tools:${PATH}"
 
-CMD echo 'usage: docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=us -j4\n' \
-         'see https://github.com/n64decomp/sm64/blob/master/README.md for advanced usage'
+CMD echo 'Usage: docker run --rm --mount type=bind,source="$(pwd)",destination=/hackersm64 hackersm64 make VERSION=us -j4\n' \
+         'See https://github.com/HackerN64/HackerSM64/blob/master/README.md for more information'


### PR DESCRIPTION
also:

- Fix outdated package
- Clean up usage example a bit
- Specify a different docker image name/workdir to differentiate this image with that of other forks.

Related pull for sm64ex: https://github.com/sm64pc/sm64ex/pull/538

Related pull for original decomp: https://github.com/n64decomp/sm64/pull/91