### PR TITLE
Improved wall collision checking

### DIFF
--- a/data/behavior_data.c
+++ b/data/behavior_data.c
@@ -5873,7 +5873,7 @@ const BehaviorScript bhvRacingPenguin[] = {
     OR_INT(oFlags, (OBJ_FLAG_COMPUTE_ANGLE_TO_MARIO | OBJ_FLAG_ACTIVE_FROM_AFAR | OBJ_FLAG_COMPUTE_DIST_TO_MARIO | OBJ_FLAG_SET_FACE_YAW_TO_MOVE_YAW | OBJ_FLAG_UPDATE_GFX_POS_AND_ANGLE)),
     LOAD_ANIMATIONS(oAnimations, penguin_seg5_anims_05008B74),
     ANIMATE(PENGUIN_ANIM_IDLE),
-    SET_OBJ_PHYSICS(/*Wall hitbox radius*/ 300, /*Gravity*/ -800, /*Bounciness*/ -5, /*Drag strength*/ 0, /*Friction*/ 0, /*Buoyancy*/ 0, /*Unused*/ 0, 0),
+    SET_OBJ_PHYSICS(/*Wall hitbox radius*/ 200, /*Gravity*/ -800, /*Bounciness*/ -5, /*Drag strength*/ 0, /*Friction*/ 0, /*Buoyancy*/ 0, /*Unused*/ 0, 0),
     SCALE(/*Unused*/ 0, /*Field*/ 400),
     CALL_NATIVE(bhv_racing_penguin_init),
     BEGIN_LOOP(),

--- a/src/engine/surface_collision.c
+++ b/src/engine/surface_collision.c
@@ -63,11 +63,6 @@ static s32 find_wall_collisions_from_list(struct SurfaceNode *surfaceNode, struc
     TerrainData type = SURFACE_DEFAULT;
     s32 numCols = 0;
 
-    // Max collision radius = 200
-    if (radius > 200) {
-        radius = 200;
-    }
-
     f32 margin_radius = radius - 1.0f;
 
     // Stay in this loop until out of walls.
@@ -216,18 +211,24 @@ s32 find_wall_collisions(struct WallCollisionData *colData) {
     }
 
     // World (level) consists of a 16x16 grid. Find where the collision is on the grid (round toward -inf)
-    s32 cellX = GET_CELL_COORD(x);
-    s32 cellZ = GET_CELL_COORD(z);
+    s32 minCellX = GET_CELL_COORD(x - colData->radius);
+    s32 minCellZ = GET_CELL_COORD(z - colData->radius);
+    s32 maxCellX = GET_CELL_COORD(x + colData->radius);
+    s32 maxCellZ = GET_CELL_COORD(z + colData->radius);
 
-    if (!(gCollisionFlags & COLLISION_FLAG_EXCLUDE_DYNAMIC)) {
-        // Check for surfaces belonging to objects.
-        node = gDynamicSurfacePartition[cellZ][cellX][SPATIAL_PARTITION_WALLS].next;
-        numCollisions += find_wall_collisions_from_list(node, colData);
+    for (s32 cellX = minCellX; cellX <= maxCellX; cellX++) {
+        for (s32 cellZ = minCellZ; cellZ <= maxCellZ; cellZ++) {
+            if (!(gCollisionFlags & COLLISION_FLAG_EXCLUDE_DYNAMIC)) {
+                // Check for surfaces belonging to objects.
+                node = gDynamicSurfacePartition[cellZ][cellX][SPATIAL_PARTITION_WALLS].next;
+                numCollisions += find_wall_collisions_from_list(node, colData);
+            }
+
+            // Check for surfaces that are a part of level geometry.
+            node = gStaticSurfacePartition[cellZ][cellX][SPATIAL_PARTITION_WALLS].next;
+            numCollisions += find_wall_collisions_from_list(node, colData);
+        }
     }
-
-    // Check for surfaces that are a part of level geometry.
-    node = gStaticSurfacePartition[cellZ][cellX][SPATIAL_PARTITION_WALLS].next;
-    numCollisions += find_wall_collisions_from_list(node, colData);
 
     gCollisionFlags &= ~(COLLISION_FLAG_RETURN_FIRST | COLLISION_FLAG_EXCLUDE_DYNAMIC | COLLISION_FLAG_INCLUDE_INTANGIBLE);
 #ifdef VANILLA_DEBUG

--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -187,13 +187,6 @@ static s32 lower_cell_index(s32 coord) {
     // [0, NUM_CELLS)
     s32 index = coord / CELL_SIZE;
 
-    // Include extra cell if close to boundary
-    //! Some wall checks are larger than the buffer, meaning wall checks can
-    //  miss walls that are near a cell border.
-    if (coord % CELL_SIZE < 50) {
-        index--;
-    }
-
     // Potentially > NUM_CELLS - 1, but since the upper index is <= NUM_CELLS - 1, not exploitable
     return MAX(0, index);
 }
@@ -212,13 +205,6 @@ static s32 upper_cell_index(s32 coord) {
 
     // [0, NUM_CELLS)
     s32 index = coord / CELL_SIZE;
-
-    // Include extra cell if close to boundary
-    //! Some wall checks are larger than the buffer, meaning wall checks can
-    //  miss walls that are near a cell border.
-    if (coord % CELL_SIZE > CELL_SIZE - 50) {
-        index++;
-    }
 
     // Potentially < 0, but since lower index is >= 0, not exploitable
     return MIN((NUM_CELLS - 1), index);


### PR DESCRIPTION
In vanilla, to account for wall checks while near a cell boundary, each cell actually contains surfaces that lie up to a hardcoded 50 units outside of its boundaries, so that walls aren't missed. This introduces a bug where wall checks greater than 50 units in radius can miss walls (this is noticeable in vanilla when swimming as Mario has a 100 unit radius there, and this bug can be observed in THI). This PR fixes this bug and also improves performance and RAM usage. (This is something Kaze has done in RTYI, and I have also tested it in both rando and Mario Builder.)

* Cells no longer have the 50 unit buffer outside of their boundaries, reducing the number of surface nodes allocated and reducing RAM usage.

* Wall collision checks now use the radius to determine if they should check multiple cells at once, fixing the problem of not finding walls when near a cell boundary. It might seem like this would lower performance but it actually improves it for a few reasons:
* * Because each cell now has fewer surfaces, the iteration when collision checking is lower for all collision checks.
* * Only very few wall collision checks will actually iterate over multiple cells, those being the objects that are at a cell boundary, which is 0 most of the time and only higher occasionally.
* * Only wall collision needs the extra cell checks, but all types of collision checks including floors and ceilings benefit in performance from not having as many surfaces in each cell.

* Wall collision checks will now work as expected with any collision radius.

* The hardcoded max radius of 200 has been removed, new people might find it confusing if they wanted to do a bigger check. The only object in vanilla that has a radius bigger than 200 is the racing penguin, so I have lowered its radius to 200 to be equivalent to vanilla and ensured it can still complete the slide without falling off.