### PR TITLE
Add assert for beginning geo layout command

### DIFF
--- a/include/config/config_safeguards.h
+++ b/include/config/config_safeguards.h
@@ -132,6 +132,11 @@
     #define UNLOCK_ALL
 #endif // COMPLETE_SAVE_FILE
 
+#ifdef DEBUG
+    #undef DEBUG_ASSERTIONS
+    #define DEBUG_ASSERTIONS
+#endif // DEBUG
+
 
 /*****************
  * config_camera.h

--- a/include/geo_commands.h
+++ b/include/geo_commands.h
@@ -58,6 +58,8 @@ enum GeoLayoutCommands {
     /*0x1E*/ GEO_CMD_NOP_1E,
     /*0x1F*/ GEO_CMD_NOP_1F,
     /*0x20*/ GEO_CMD_NODE_CULLING_RADIUS,
+
+    GEO_CMD_COUNT,
 };
 
 // geo layout macros

--- a/src/engine/geo_layout.c
+++ b/src/engine/geo_layout.c
@@ -772,7 +772,7 @@ struct GraphNode *process_geo_layout(struct AllocOnlyPool *pool, void *segptr) {
     gGeoLayoutStack[1] = 0;
 
     while (gGeoLayoutCommand != NULL) {
-        assert((gGeoLayoutCommand[0x00] < GEO_CMD_COUNT), "Tried to load an invalid geo layout.")
+        assert((gGeoLayoutCommand[0x00] < GEO_CMD_COUNT), "Invalid or unloaded geo layout detected.");
         GeoLayoutJumpTable[gGeoLayoutCommand[0x00]]();
     }
 

--- a/src/engine/geo_layout.c
+++ b/src/engine/geo_layout.c
@@ -771,17 +771,8 @@ struct GraphNode *process_geo_layout(struct AllocOnlyPool *pool, void *segptr) {
     gGeoLayoutStack[0] = 0;
     gGeoLayoutStack[1] = 0;
 
-    // Make sure the initial command is valid to start a geo layout.
-    assert((gGeoLayoutCommand[0x00] == GEO_CMD_NODE_ROOT) ||
-           (gGeoLayoutCommand[0x00] == GEO_CMD_NODE_START) ||
-           (gGeoLayoutCommand[0x00] == GEO_CMD_NODE_SWITCH_CASE) ||
-           (gGeoLayoutCommand[0x00] == GEO_CMD_NODE_TRANSLATION) ||
-           (gGeoLayoutCommand[0x00] == GEO_CMD_NODE_SHADOW) ||
-           (gGeoLayoutCommand[0x00] == GEO_CMD_NODE_SCALE) ||
-           (gGeoLayoutCommand[0x00] == GEO_CMD_NODE_CULLING_RADIUS),
-           "Tried to load an invalid geo layout.");
-
     while (gGeoLayoutCommand != NULL) {
+        assert((gGeoLayoutCommand[0x00] < GEO_CMD_COUNT), "Tried to load an invalid geo layout.")
         GeoLayoutJumpTable[gGeoLayoutCommand[0x00]]();
     }
 

--- a/src/engine/geo_layout.c
+++ b/src/engine/geo_layout.c
@@ -5,6 +5,7 @@
 #include "math_util.h"
 #include "game/memory.h"
 #include "graph_node.h"
+#include "game/debug.h"
 
 typedef void (*GeoLayoutCommandProc)(void);
 
@@ -769,6 +770,16 @@ struct GraphNode *process_geo_layout(struct AllocOnlyPool *pool, void *segptr) {
 
     gGeoLayoutStack[0] = 0;
     gGeoLayoutStack[1] = 0;
+
+    // Make sure the initial command is valid to start a geo layout.
+    assert((gGeoLayoutCommand[0x00] == GEO_CMD_NODE_ROOT) ||
+           (gGeoLayoutCommand[0x00] == GEO_CMD_NODE_START) ||
+           (gGeoLayoutCommand[0x00] == GEO_CMD_NODE_SWITCH_CASE) ||
+           (gGeoLayoutCommand[0x00] == GEO_CMD_NODE_TRANSLATION) ||
+           (gGeoLayoutCommand[0x00] == GEO_CMD_NODE_SHADOW) ||
+           (gGeoLayoutCommand[0x00] == GEO_CMD_NODE_SCALE) ||
+           (gGeoLayoutCommand[0x00] == GEO_CMD_NODE_CULLING_RADIUS),
+           "Tried to load an invalid geo layout.");
 
     while (gGeoLayoutCommand != NULL) {
         GeoLayoutJumpTable[gGeoLayoutCommand[0x00]]();

--- a/src/game/crash_screen.c
+++ b/src/game/crash_screen.c
@@ -133,6 +133,7 @@ void crash_screen_print(s32 x, s32 y, const char *fmt, ...) {
     char *ptr;
     u32 glyph;
     s32 size;
+    s32 xOffset = x;
     char buf[0x108];
     bzero(&buf, sizeof(buf));
 
@@ -147,12 +148,15 @@ void crash_screen_print(s32 x, s32 y, const char *fmt, ...) {
         while (*ptr) {
             glyph = gCrashScreenCharToGlyph[*ptr & 0x7f];
 
-            if (glyph != 0xff) {
-                crash_screen_draw_glyph(x, y, glyph);
+            if (*ptr == '\n') {
+                xOffset = x;
+                y += 10;
+            } else if (glyph != 0xff) {
+                crash_screen_draw_glyph(xOffset, y, glyph);
             }
 
             ptr++;
-            x += 6;
+            xOffset += 6;
         }
     }
 

--- a/src/game/debug.h
+++ b/src/game/debug.h
@@ -62,7 +62,7 @@ extern void __n64Assert(char *fileName, u32 lineNum, char *message);
 /**
  * Will cause a crash if cond is not true, and DEBUG is defined (allows for quick removal of littered asserts)
  */
-#if defined(DEBUG) || defined(DEBUG_ASSERTIONS)
+#ifdef DEBUG_ASSERTIONS
 #define assert(cond, message) do {\
     if ((cond) == FALSE) { \
         error(message); \


### PR DESCRIPTION
Fixes #570. Checks if the beginning command of the geo layout is a valid command to start, to make it easier to tell when an invalid model is trying to load.

The check is kinda hardcoded, but doing it with just a range check for a valid geo layout command makes the assert have too many false negatives to be useful.