### PR TITLE
Define changes for transitions, two bug fixes

### DIFF
--- a/include/config/config_graphics.h
+++ b/include/config/config_graphics.h
@@ -141,9 +141,10 @@
 #define DEFAULT_CULLING_RADIUS 300
 
 /**
- * Eases the textured screen transitions to make them look smoother.
+ * Eases the textured screen transitions to make them look smoother. 
+ * Extends the full radius for mario, bowser and the star transitions.
  */
-#define EASE_IN_OUT_TRANSITIONS
+// #define POLISHED_TRANSITIONS
 
 /**
  * Uses frustratio of 2 instead of 1.

--- a/src/game/area.c
+++ b/src/game/area.c
@@ -336,7 +336,7 @@ void play_transition(s16 transType, s16 time, Color red, Color green, Color blue
         gWarpTransition.data.green = green;
         gWarpTransition.data.blue = blue;
     } else { // if transition is textured
-        set_and_reset_transition_timers(0); // Reset transition timers by passing in 0 for time
+        set_and_reset_transition_fade_timer(0); // Reset transition timers by passing in 0 for time
 
         gWarpTransition.data.red = red;
         gWarpTransition.data.green = green;

--- a/src/game/area.c
+++ b/src/game/area.c
@@ -331,11 +331,13 @@ void play_transition(s16 transType, s16 time, Color red, Color green, Color blue
         red = gWarpTransRed, green = gWarpTransGreen, blue = gWarpTransBlue;
     }
 
-    if (transType < WARP_TRANSITION_TYPE_STAR) { // if transition is WARP_TRANSITION_TYPE_COLOR
+    if (transType & WARP_TRANSITION_TYPE_COLOR) {
         gWarpTransition.data.red = red;
         gWarpTransition.data.green = green;
         gWarpTransition.data.blue = blue;
     } else { // if transition is textured
+        set_and_reset_transition_timers(0); // Reset transition timers by passing in 0 for time
+
         gWarpTransition.data.red = red;
         gWarpTransition.data.green = green;
         gWarpTransition.data.blue = blue;
@@ -353,8 +355,7 @@ void play_transition(s16 transType, s16 time, Color red, Color green, Color blue
 
         s16 fullRadius = GFX_DIMENSIONS_FULL_RADIUS;
 
-        // HackerSM64: this fixes the pop-in with texture transition, comment out this switch
-        // statement if you want to restore the original full radius.
+#ifdef POLISHED_TRANSITIONS
         switch (transType){
             case WARP_TRANSITION_TYPE_BOWSER:
             case WARP_TRANSITION_FADE_INTO_BOWSER:
@@ -369,6 +370,7 @@ void play_transition(s16 transType, s16 time, Color red, Color green, Color blue
                 fullRadius *= 1.5f;
             break;
         }
+#endif
 
         if (transType & WARP_TRANSITION_FADE_INTO) { // Is the image fading in?
             gWarpTransition.data.startTexRadius = fullRadius;

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -382,10 +382,8 @@ void init_mario_after_warp(void) {
     sDelayedWarpOp = WARP_OP_NONE;
 
     switch (marioSpawnType) {
-        case MARIO_SPAWN_PIPE:
-            play_transition(WARP_TRANSITION_FADE_FROM_STAR, 0x10, 0x00, 0x00, 0x00);
-            break;
         case MARIO_SPAWN_DOOR_WARP:
+        case MARIO_SPAWN_SPIN_AIRBORNE_CIRCLE:
             play_transition(WARP_TRANSITION_FADE_FROM_CIRCLE, 0x10, 0x00, 0x00, 0x00);
             break;
         case MARIO_SPAWN_TELEPORT:
@@ -393,9 +391,6 @@ void init_mario_after_warp(void) {
             break;
         case MARIO_SPAWN_SPIN_AIRBORNE:
             play_transition(WARP_TRANSITION_FADE_FROM_COLOR, 0x1A, 0xFF, 0xFF, 0xFF);
-            break;
-        case MARIO_SPAWN_SPIN_AIRBORNE_CIRCLE:
-            play_transition(WARP_TRANSITION_FADE_FROM_CIRCLE, 0x10, 0x00, 0x00, 0x00);
             break;
         case MARIO_SPAWN_FADE_FROM_BLACK:
             play_transition(WARP_TRANSITION_FADE_FROM_COLOR, 0x10, 0x00, 0x00, 0x00);

--- a/src/game/screen_transition.c
+++ b/src/game/screen_transition.c
@@ -24,7 +24,7 @@ void *sTextureTransitionID[] = {
 };
 
 
-s32 set_and_reset_transition_fade_timer(u8 transTime) {
+s32 set_and_reset_transition_timers(u8 transTime) {
     sTransitionFadeTimer++;
 
     if (sTransitionFadeTimer >= transTime) {
@@ -81,10 +81,10 @@ void make_tex_transition_vertices(Vtx *verts, f32 centerTransX, f32 centerTransY
     make_tex_transition_vertex(verts, 7, centerTransX, centerTransY, -SOLID_COL_RADIUS, SOLID_COL_RADIUS, 0, 0);
 }
 
-f32 calc_tex_transition_radius(s8 transTime, struct WarpTransitionData *transData) {
+f32 calc_tex_transition_radius(u8 transTime, struct WarpTransitionData *transData) {
     f32 amount = (f32) sTransitionFadeTimer / (f32) (transTime - 1);
 
-#ifdef EASE_IN_OUT_TRANSITIONS
+#ifdef POLISHED_TRANSITIONS
     return smoothstep(transData->startTexRadius, transData->endTexRadius, amount);
 #else
     return lerpf(transData->startTexRadius, transData->endTexRadius, amount);
@@ -128,7 +128,7 @@ u16 calc_tex_transition_direction(struct WarpTransitionData *transData) {
  * Called during render_screen_transition.
  * Handles shape transitions (such as the star, circle and Mario and bowser´s heads).
  */
-s32 render_textured_transition(s8 transTime, struct WarpTransitionData *transData, s8 texID, s8 transTexType) {
+s32 render_textured_transition(u8 transTime, struct WarpTransitionData *transData, s8 texID, s8 transTexType) {
     u16 texTransDir = calc_tex_transition_direction(transData);
 
     f32 posDistance = calc_tex_transition_pos_distance(transTime, transData);
@@ -137,7 +137,6 @@ s32 render_textured_transition(s8 transTime, struct WarpTransitionData *transDat
 
     f32 texTransRadius = calc_tex_transition_radius(transTime, transData);
     Vtx *verts = alloc_display_list(8 * sizeof(Vtx));
-
 
     if (verts != NULL) {
         make_tex_transition_vertices(verts, centerTransX, centerTransY, texTransRadius, transTexType);
@@ -178,7 +177,7 @@ s32 render_textured_transition(s8 transTime, struct WarpTransitionData *transDat
         gSPDisplayList(gDisplayListHead++, dl_screen_transition_end);
         sTransitionTextureAngle += transData->angleSpeed;
     }
-    return set_and_reset_transition_fade_timer(transTime);
+    return set_and_reset_transition_timers(transTime);
 }
 
 Vtx *vertex_transition_color() {
@@ -209,7 +208,7 @@ s32 dl_transition_color(u8 transTime, struct WarpTransitionData *transData, u8 a
         gSPDisplayList(gDisplayListHead++, dl_draw_quad_verts_0123);
         gSPDisplayList(gDisplayListHead++, dl_screen_transition_end);
     }
-    return set_and_reset_transition_fade_timer(transTime);
+    return set_and_reset_transition_timers(transTime);
 }
 
 u8 set_transition_color_fade_alpha(s8 fadeType, u8 transTime) {
@@ -253,29 +252,21 @@ s32 render_screen_transition(s8 transType, u8 transTime, struct WarpTransitionDa
             break;
         
         case WARP_TRANSITION_FADE_FROM_STAR:
-            return render_textured_transition(transTime, transData, TEX_TRANS_STAR, TRANS_TYPE_MIRROR);
-            break;
         case WARP_TRANSITION_FADE_INTO_STAR:
             return render_textured_transition(transTime, transData, TEX_TRANS_STAR, TRANS_TYPE_MIRROR);
             break;
         
         case WARP_TRANSITION_FADE_FROM_CIRCLE:
-            return render_textured_transition(transTime, transData, TEX_TRANS_CIRCLE, TRANS_TYPE_MIRROR);
-            break;
         case WARP_TRANSITION_FADE_INTO_CIRCLE:
             return render_textured_transition(transTime, transData, TEX_TRANS_CIRCLE, TRANS_TYPE_MIRROR);
             break;
         
         case WARP_TRANSITION_FADE_FROM_MARIO:
-            return render_textured_transition(transTime, transData, TEX_TRANS_MARIO, TRANS_TYPE_CLAMP);
-            break;
         case WARP_TRANSITION_FADE_INTO_MARIO:
             return render_textured_transition(transTime, transData, TEX_TRANS_MARIO, TRANS_TYPE_CLAMP);
             break;
         
         case WARP_TRANSITION_FADE_FROM_BOWSER:
-            return render_textured_transition(transTime, transData, TEX_TRANS_BOWSER, TRANS_TYPE_MIRROR);
-            break;
         case WARP_TRANSITION_FADE_INTO_BOWSER:
             return render_textured_transition(transTime, transData, TEX_TRANS_BOWSER, TRANS_TYPE_MIRROR);
             break;

--- a/src/game/screen_transition.c
+++ b/src/game/screen_transition.c
@@ -24,7 +24,7 @@ void *sTextureTransitionID[] = {
 };
 
 
-s32 set_and_reset_transition_timers(u8 transTime) {
+s32 set_and_reset_transition_fade_timer(u8 transTime) {
     sTransitionFadeTimer++;
 
     if (sTransitionFadeTimer >= transTime) {
@@ -177,7 +177,7 @@ s32 render_textured_transition(u8 transTime, struct WarpTransitionData *transDat
         gSPDisplayList(gDisplayListHead++, dl_screen_transition_end);
         sTransitionTextureAngle += transData->angleSpeed;
     }
-    return set_and_reset_transition_timers(transTime);
+    return set_and_reset_transition_fade_timer(transTime);
 }
 
 Vtx *vertex_transition_color() {
@@ -208,7 +208,7 @@ s32 dl_transition_color(u8 transTime, struct WarpTransitionData *transData, u8 a
         gSPDisplayList(gDisplayListHead++, dl_draw_quad_verts_0123);
         gSPDisplayList(gDisplayListHead++, dl_screen_transition_end);
     }
-    return set_and_reset_transition_timers(transTime);
+    return set_and_reset_transition_fade_timer(transTime);
 }
 
 u8 set_transition_color_fade_alpha(s8 fadeType, u8 transTime) {

--- a/src/game/screen_transition.h
+++ b/src/game/screen_transition.h
@@ -24,7 +24,7 @@ enum ColorTransitionFade {
     COLOR_TRANS_FADE_FROM_COLOR,
 };
 
-s32 set_and_reset_transition_timers(u8 transTime);
+s32 set_and_reset_transition_fade_timer(u8 transTime);
 s32 render_screen_transition(s8 transType, u8 transTime, struct WarpTransitionData *transData);
 Gfx *geo_cannon_circle_base(s32 callContext, struct GraphNode *node, UNUSED Mat4 mtx);
 

--- a/src/game/screen_transition.h
+++ b/src/game/screen_transition.h
@@ -24,6 +24,7 @@ enum ColorTransitionFade {
     COLOR_TRANS_FADE_FROM_COLOR,
 };
 
+s32 set_and_reset_transition_timers(u8 transTime);
 s32 render_screen_transition(s8 transType, u8 transTime, struct WarpTransitionData *transData);
 Gfx *geo_cannon_circle_base(s32 callContext, struct GraphNode *node, UNUSED Mat4 mtx);
 


### PR DESCRIPTION
Fixed higher time transitions not working (up to 255 frames right now) and fixed transitions not starting properly when interrupting another transition, cleaned up a few things, put every non vanilla styled change into POLISHED_TRANSITIONS and renamed set_and_reset_transition_fade_timer
Arthurtilly and Artic wanted this reverted by default, i think a "correct" full radius counts as a fix and smoothstep fixes the "ended before you'd expect" look that linear has, but I understand now why maybe it should be left commented out by default.
I tried also adjusting the times with POLISHED_TRANSITIONS but it looked very out of place, more than some faster looking transitions did.