### PR TITLE
Fix Boo's Accelerating Upwards During Textbox (Vanilla Bug)

### DIFF
--- a/src/game/behaviors/boo.inc.c
+++ b/src/game/behaviors/boo.inc.c
@@ -278,6 +278,7 @@ static s32 boo_update_during_death(void) {
 
         if (o->oTimer > 30 || o->oMoveFlags & OBJ_MOVE_HIT_WALL) {
             spawn_mist_particles();
+            boo_stop();
             o->oBooDeathStatus = BOO_DEATH_STATUS_DEAD;
 
             if (o->oBooParentBigBoo != NULL) {


### PR DESCRIPTION
If a `Go On A Ghost Hunt` Boo is killed while it has a gravity of -1 (at the bottom of its oscillation), and does not hit a wall, it will keep the same negative gravity and continue moving until the textbox is closed. Boo Y speed isn't capped in this scenario, so the constant -1 gravity leads to the boo moving upwards at an increasing rate.

This leads to issues in `boo_act_4`. The distance eventually increases to a point where any other boo object is too far to be returned in `cur_obj_nearest_object_with_behavior`. 

This can have 2 buggy effects:

- the wrong dialog box being brought up if the textbox is delayed (easiest to do by hanging on a ledge).
- the puzzle solved jingle being played incorrectly if you wait in the textbox long enough

This doesn't actually cause issues with King Boo, it just brings up the wrong text box. King Boo spawning is unaffected by this bug.

The fix is to stop the boo after the death animation has finished playing, stopping the boo from accelerating upwards. I don't believe this to cause any other issues (the boo is already dead after all!)

Thanks to Kyman for finding this bug.