### PR TITLE
Add `-falign-functions=32` to makefile flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ endif
 #==============================================================================#
 
 # Default non-gcc opt flags
-DEFAULT_OPT_FLAGS = -Ofast
+DEFAULT_OPT_FLAGS = -Ofast -falign-functions=32
 # Note: -fno-associative-math is used here to suppress warnings, ideally we would enable this as an optimization but
 # this conflicts with -ftrapping-math apparently.
 # TODO: Figure out how to allow -fassociative-math to be enabled


### PR DESCRIPTION
Seemingly provides minor performance benefit and should more importantly reduce perf lotto substantially (hopefully)