### PR TITLE
Label unlabelled audio func (func_80321080 to stop_secondary_music)

### DIFF
--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -2371,9 +2371,9 @@ void play_secondary_music(u8 seqId, u8 bgMusicVolume, u8 volume, u16 fadeTimer) 
 
 /**
  * Called from threads: thread5_game_loop
- * Seems to be related to music fading based on position, such as sleeping Piranha Plants, BBH Merry-Go-Round, and Endless Stairs
+ * Plays the primary music and stops playing the secondary music. Call it to cancel the above function.
  */
-void func_80321080(u16 fadeTimer) {
+void play_primary_music(u16 fadeTimer) {
     if (sBackgroundMusicTargetVolume != TARGET_VOLUME_UNSET) {
         sBackgroundMusicTargetVolume = TARGET_VOLUME_UNSET;
         D_80332120 = 0;

--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -2373,7 +2373,7 @@ void play_secondary_music(u8 seqId, u8 bgMusicVolume, u8 volume, u16 fadeTimer) 
  * Called from threads: thread5_game_loop
  * Plays the primary music and stops playing the secondary music. Call it to cancel the above function.
  */
-void play_primary_music(u16 fadeTimer) {
+void stop_secondary_music(u16 fadeTimer) {
     if (sBackgroundMusicTargetVolume != TARGET_VOLUME_UNSET) {
         sBackgroundMusicTargetVolume = TARGET_VOLUME_UNSET;
         D_80332120 = 0;

--- a/src/audio/external.h
+++ b/src/audio/external.h
@@ -62,7 +62,7 @@ void fadeout_background_music(u16 seqId, u16 fadeOut);
 void drop_queued_background_music(void);
 u32 get_current_background_music(void);
 void play_secondary_music(u8 seqId, u8 bgMusicVolume, u8 volume, u16 fadeTimer);
-void play_primary_music(u16 fadeTimer);
+void stop_secondary_music(u16 fadeTimer);
 void func_803210D4(u16 fadeOutTime);
 void play_course_clear(s32 isKey);
 void play_peachs_jingle(void);

--- a/src/audio/external.h
+++ b/src/audio/external.h
@@ -62,7 +62,7 @@ void fadeout_background_music(u16 seqId, u16 fadeOut);
 void drop_queued_background_music(void);
 u32 get_current_background_music(void);
 void play_secondary_music(u8 seqId, u8 bgMusicVolume, u8 volume, u16 fadeTimer);
-void func_80321080(u16 fadeTimer);
+void play_primary_music(u16 fadeTimer);
 void func_803210D4(u16 fadeOutTime);
 void play_course_clear(s32 isKey);
 void play_peachs_jingle(void);

--- a/src/game/behaviors/bbh_merry_go_round.inc.c
+++ b/src/game/behaviors/bbh_merry_go_round.inc.c
@@ -53,7 +53,7 @@ static void handle_merry_go_round_music(void) {
             // The merry-go-round is a dynamic surface.
             gMarioCurrentRoom != BBH_DYNAMIC_SURFACE_ROOM
             && gMarioCurrentRoom != BBH_NEAR_MERRY_GO_ROUND_ROOM) {
-            play_primary_music(300); //! Switch to BBH music? FIXME: Audio needs labelling
+            play_primary_music(300);
             o->oMerryGoRoundMusicShouldPlay = FALSE;
         } else {
             cur_obj_play_sound_1(SOUND_ENV_MERRY_GO_ROUND_CREAKING);
@@ -94,6 +94,6 @@ void bhv_merry_go_round_loop(void) {
         handle_merry_go_round_music();
     } else {
         o->oAngleVelYaw = 0;
-        play_primary_music(300); //! Switch to BBH music? FIXME: Audio needs labelling
+        play_primary_music(300);
     }
 }

--- a/src/game/behaviors/bbh_merry_go_round.inc.c
+++ b/src/game/behaviors/bbh_merry_go_round.inc.c
@@ -53,7 +53,7 @@ static void handle_merry_go_round_music(void) {
             // The merry-go-round is a dynamic surface.
             gMarioCurrentRoom != BBH_DYNAMIC_SURFACE_ROOM
             && gMarioCurrentRoom != BBH_NEAR_MERRY_GO_ROUND_ROOM) {
-            play_primary_music(300);
+            stop_secondary_music(300);
             o->oMerryGoRoundMusicShouldPlay = FALSE;
         } else {
             cur_obj_play_sound_1(SOUND_ENV_MERRY_GO_ROUND_CREAKING);
@@ -94,6 +94,6 @@ void bhv_merry_go_round_loop(void) {
         handle_merry_go_round_music();
     } else {
         o->oAngleVelYaw = 0;
-        play_primary_music(300);
+        stop_secondary_music(300);
     }
 }

--- a/src/game/behaviors/bbh_merry_go_round.inc.c
+++ b/src/game/behaviors/bbh_merry_go_round.inc.c
@@ -53,7 +53,7 @@ static void handle_merry_go_round_music(void) {
             // The merry-go-round is a dynamic surface.
             gMarioCurrentRoom != BBH_DYNAMIC_SURFACE_ROOM
             && gMarioCurrentRoom != BBH_NEAR_MERRY_GO_ROUND_ROOM) {
-            func_80321080(300); //! Switch to BBH music? FIXME: Audio needs labelling
+            play_primary_music(300); //! Switch to BBH music? FIXME: Audio needs labelling
             o->oMerryGoRoundMusicShouldPlay = FALSE;
         } else {
             cur_obj_play_sound_1(SOUND_ENV_MERRY_GO_ROUND_CREAKING);
@@ -94,6 +94,6 @@ void bhv_merry_go_round_loop(void) {
         handle_merry_go_round_music();
     } else {
         o->oAngleVelYaw = 0;
-        func_80321080(300); //! Switch to BBH music? FIXME: Audio needs labelling
+        play_primary_music(300); //! Switch to BBH music? FIXME: Audio needs labelling
     }
 }

--- a/src/game/behaviors/piranha_plant.inc.c
+++ b/src/game/behaviors/piranha_plant.inc.c
@@ -38,7 +38,7 @@ s32 piranha_plant_check_interactions(void) {
     s32 i;
 
     if (o->oInteractStatus & INT_STATUS_INTERACTED) {
-        func_80321080(50);
+        play_primary_music(50);
         if (o->oInteractStatus & INT_STATUS_WAS_ATTACKED) {
             cur_obj_play_sound_2(SOUND_OBJ2_PIRANHA_PLANT_DYING);
 
@@ -89,7 +89,7 @@ void piranha_plant_act_sleeping(void) {
         o->oPiranhaPlantSleepMusicState = PIRANHA_PLANT_SLEEP_MUSIC_PLAYING;
     } else if (o->oPiranhaPlantSleepMusicState == PIRANHA_PLANT_SLEEP_MUSIC_PLAYING) {
         o->oPiranhaPlantSleepMusicState++;
-        func_80321080(50);
+        play_primary_music(50);
     }
     piranha_plant_check_interactions();
 }
@@ -104,7 +104,7 @@ void piranha_plant_act_woken_up(void) {
      */
     o->oDamageOrCoinValue = 3;
     if (o->oTimer == 0) {
-        func_80321080(50);
+        play_primary_music(50);
     }
 
     if (!piranha_plant_check_interactions() && o->oTimer > 10) {

--- a/src/game/behaviors/piranha_plant.inc.c
+++ b/src/game/behaviors/piranha_plant.inc.c
@@ -38,7 +38,7 @@ s32 piranha_plant_check_interactions(void) {
     s32 i;
 
     if (o->oInteractStatus & INT_STATUS_INTERACTED) {
-        play_primary_music(50);
+        stop_secondary_music(50);
         if (o->oInteractStatus & INT_STATUS_WAS_ATTACKED) {
             cur_obj_play_sound_2(SOUND_OBJ2_PIRANHA_PLANT_DYING);
 
@@ -89,7 +89,7 @@ void piranha_plant_act_sleeping(void) {
         o->oPiranhaPlantSleepMusicState = PIRANHA_PLANT_SLEEP_MUSIC_PLAYING;
     } else if (o->oPiranhaPlantSleepMusicState == PIRANHA_PLANT_SLEEP_MUSIC_PLAYING) {
         o->oPiranhaPlantSleepMusicState++;
-        play_primary_music(50);
+        stop_secondary_music(50);
     }
     piranha_plant_check_interactions();
 }
@@ -104,7 +104,7 @@ void piranha_plant_act_woken_up(void) {
      */
     o->oDamageOrCoinValue = 3;
     if (o->oTimer == 0) {
-        play_primary_music(50);
+        stop_secondary_music(50);
     }
 
     if (!piranha_plant_check_interactions() && o->oTimer > 10) {

--- a/src/game/sound_init.c
+++ b/src/game/sound_init.c
@@ -220,7 +220,7 @@ void play_infinite_stairs_music(void) {
         if (shouldPlay) {
             play_secondary_music(SEQ_EVENT_ENDLESS_STAIRS, 0, 255, 1000);
         } else {
-            play_primary_music(500);
+            stop_secondary_music(500);
         }
     }
 #endif

--- a/src/game/sound_init.c
+++ b/src/game/sound_init.c
@@ -220,7 +220,7 @@ void play_infinite_stairs_music(void) {
         if (shouldPlay) {
             play_secondary_music(SEQ_EVENT_ENDLESS_STAIRS, 0, 255, 1000);
         } else {
-            func_80321080(500);
+            play_primary_music(500);
         }
     }
 #endif


### PR DESCRIPTION
I've used this function a bunch in my hacks and it's weird that it isn't labelled. It isn't some obscure function you'd never want to use, it's just to cancel the secondary music (like the piranha plant lullaby) and go back to playing the level's music.