### PR TITLE
(WIP) make per-level segment loading not suck

### DIFF
--- a/include/level_commands.h
+++ b/include/level_commands.h
@@ -490,13 +490,24 @@ enum GoddardScene {
     LOAD_YAY0(/*seg*/ SEGMENT_GROUPA_YAY0, /*romStart*/ _##groupName##_yay0SegmentRomStart, /*romEnd*/ _##groupName##_yay0SegmentRomEnd), \
     LOAD_RAW( /*seg*/ SEGMENT_GROUPA_GEO,  /*romStart*/ _##groupName##_geoSegmentRomStart,  /*romEnd*/ _##groupName##_geoSegmentRomEnd)
 
+#define LOAD_GROUPA_FULL(groupName) \
+    LOAD_YAY0(/*seg*/ SEGMENT_GROUPA_YAY0, /*romStart*/ _##groupName##_yay0SegmentRomStart, /*romEnd*/ _##groupName##_yay0SegmentRomEnd), \
+    LOAD_RAW( /*seg*/ SEGMENT_GROUPA_GEO,  /*romStart*/ _##groupName##_geoSegmentRomStart,  /*romEnd*/ _##groupName##_geoSegmentRomEnd),  \
+    JUMP_LINK(groupName ## _load_geolayouts)
+
 #define LOAD_GROUPB(groupName) \
     LOAD_YAY0(/*seg*/ SEGMENT_GROUPB_YAY0, /*romStart*/ _##groupName##_yay0SegmentRomStart, /*romEnd*/ _##groupName##_yay0SegmentRomEnd), \
     LOAD_RAW (/*seg*/ SEGMENT_GROUPB_GEO,  /*romStart*/ _##groupName##_geoSegmentRomStart,  /*romEnd*/ _##groupName##_geoSegmentRomEnd)
 
+#define LOAD_GROUPB_FULL(groupName) \
+    LOAD_YAY0(/*seg*/ SEGMENT_GROUPB_YAY0, /*romStart*/ _##groupName##_yay0SegmentRomStart, /*romEnd*/ _##groupName##_yay0SegmentRomEnd), \
+    LOAD_RAW (/*seg*/ SEGMENT_GROUPB_GEO,  /*romStart*/ _##groupName##_geoSegmentRomStart,  /*romEnd*/ _##groupName##_geoSegmentRomEnd),  \
+    JUMP_LINK(groupName ## _load_geolayouts)
+
 #define LOAD_COMMON0() \
     LOAD_YAY0(/*seg*/ SEGMENT_COMMON0_YAY0, /*romStart*/ _common0_yay0SegmentRomStart, /*romEnd*/ _common0_yay0SegmentRomEnd), \
-    LOAD_RAW( /*seg*/ SEGMENT_COMMON0_GEO,  /*romStart*/ _common0_geoSegmentRomStart,  /*romEnd*/ _common0_geoSegmentRomEnd)
+    LOAD_RAW( /*seg*/ SEGMENT_COMMON0_GEO,  /*romStart*/ _common0_geoSegmentRomStart,  /*romEnd*/ _common0_geoSegmentRomEnd),  \
+    JUMP_LINK(groupName ## _load_geolayouts)
 
 #define LOAD_BEHAVIOR_DATA() \
     LOAD_RAW( /*seg*/ SEGMENT_BEHAVIOR_DATA, /*romStart*/ _behaviorSegmentRomStart, /*romEnd*/ _behaviorSegmentRomEnd)

--- a/include/level_commands.h
+++ b/include/level_commands.h
@@ -488,18 +488,12 @@ enum GoddardScene {
 
 #define LOAD_GROUPA(groupName) \
     LOAD_YAY0(/*seg*/ SEGMENT_GROUPA_YAY0, /*romStart*/ _##groupName##_yay0SegmentRomStart, /*romEnd*/ _##groupName##_yay0SegmentRomEnd), \
-    LOAD_RAW( /*seg*/ SEGMENT_GROUPA_GEO,  /*romStart*/ _##groupName##_geoSegmentRomStart,  /*romEnd*/ _##groupName##_geoSegmentRomEnd)
-
-#define LOAD_GROUPA_FULL(groupName) \
-    LOAD_GROUPA(groupName),         \
+    LOAD_RAW( /*seg*/ SEGMENT_GROUPA_GEO,  /*romStart*/ _##groupName##_geoSegmentRomStart,  /*romEnd*/ _##groupName##_geoSegmentRomEnd),  \
     JUMP_LINK(groupName ## _load_geolayouts)
 
 #define LOAD_GROUPB(groupName) \
     LOAD_YAY0(/*seg*/ SEGMENT_GROUPB_YAY0, /*romStart*/ _##groupName##_yay0SegmentRomStart, /*romEnd*/ _##groupName##_yay0SegmentRomEnd), \
-    LOAD_RAW (/*seg*/ SEGMENT_GROUPB_GEO,  /*romStart*/ _##groupName##_geoSegmentRomStart,  /*romEnd*/ _##groupName##_geoSegmentRomEnd)
-
-#define LOAD_GROUPB_FULL(groupName) \
-    LOAD_GROUPB(groupName),         \
+    LOAD_RAW (/*seg*/ SEGMENT_GROUPB_GEO,  /*romStart*/ _##groupName##_geoSegmentRomStart,  /*romEnd*/ _##groupName##_geoSegmentRomEnd),  \
     JUMP_LINK(groupName ## _load_geolayouts)
 
 #define LOAD_COMMON0() \

--- a/include/level_commands.h
+++ b/include/level_commands.h
@@ -491,8 +491,7 @@ enum GoddardScene {
     LOAD_RAW( /*seg*/ SEGMENT_GROUPA_GEO,  /*romStart*/ _##groupName##_geoSegmentRomStart,  /*romEnd*/ _##groupName##_geoSegmentRomEnd)
 
 #define LOAD_GROUPA_FULL(groupName) \
-    LOAD_YAY0(/*seg*/ SEGMENT_GROUPA_YAY0, /*romStart*/ _##groupName##_yay0SegmentRomStart, /*romEnd*/ _##groupName##_yay0SegmentRomEnd), \
-    LOAD_RAW( /*seg*/ SEGMENT_GROUPA_GEO,  /*romStart*/ _##groupName##_geoSegmentRomStart,  /*romEnd*/ _##groupName##_geoSegmentRomEnd),  \
+    LOAD_GROUPA(groupName),         \
     JUMP_LINK(groupName ## _load_geolayouts)
 
 #define LOAD_GROUPB(groupName) \
@@ -500,14 +499,16 @@ enum GoddardScene {
     LOAD_RAW (/*seg*/ SEGMENT_GROUPB_GEO,  /*romStart*/ _##groupName##_geoSegmentRomStart,  /*romEnd*/ _##groupName##_geoSegmentRomEnd)
 
 #define LOAD_GROUPB_FULL(groupName) \
-    LOAD_YAY0(/*seg*/ SEGMENT_GROUPB_YAY0, /*romStart*/ _##groupName##_yay0SegmentRomStart, /*romEnd*/ _##groupName##_yay0SegmentRomEnd), \
-    LOAD_RAW (/*seg*/ SEGMENT_GROUPB_GEO,  /*romStart*/ _##groupName##_geoSegmentRomStart,  /*romEnd*/ _##groupName##_geoSegmentRomEnd),  \
+    LOAD_GROUPB(groupName),         \
     JUMP_LINK(groupName ## _load_geolayouts)
 
 #define LOAD_COMMON0() \
     LOAD_YAY0(/*seg*/ SEGMENT_COMMON0_YAY0, /*romStart*/ _common0_yay0SegmentRomStart, /*romEnd*/ _common0_yay0SegmentRomEnd), \
-    LOAD_RAW( /*seg*/ SEGMENT_COMMON0_GEO,  /*romStart*/ _common0_geoSegmentRomStart,  /*romEnd*/ _common0_geoSegmentRomEnd),  \
-    JUMP_LINK(groupName ## _load_geolayouts)
+    LOAD_RAW( /*seg*/ SEGMENT_COMMON0_GEO,  /*romStart*/ _common0_geoSegmentRomStart,  /*romEnd*/ _common0_geoSegmentRomEnd)
+
+#define LOAD_COMMON0_FULL() \
+    LOAD_COMMON0(),         \
+    JUMP_LINK(common0_load_geolayouts)
 
 #define LOAD_BEHAVIOR_DATA() \
     LOAD_RAW( /*seg*/ SEGMENT_BEHAVIOR_DATA, /*romStart*/ _behaviorSegmentRomStart, /*romEnd*/ _behaviorSegmentRomEnd)

--- a/levels/scripts.h
+++ b/levels/scripts.h
@@ -6,7 +6,7 @@
 
 // scripts
 extern const LevelScript level_main_scripts_entry[];
-#define common1_load_geolayouts script_func_global_1
+#define common1_load_geolayouts level_main_scripts_entry
 extern const LevelScript script_func_global_1[];
 #define common0_load_geolayouts script_func_global_1
 extern const LevelScript script_func_global_2[];

--- a/levels/scripts.h
+++ b/levels/scripts.h
@@ -6,23 +6,42 @@
 
 // scripts
 extern const LevelScript level_main_scripts_entry[];
+#define common1_load_geolayouts script_func_global_1
 extern const LevelScript script_func_global_1[];
+#define common0_load_geolayouts script_func_global_1
 extern const LevelScript script_func_global_2[];
+#define group1_load_geolayouts script_func_global_2
 extern const LevelScript script_func_global_3[];
+#define group2_load_geolayouts script_func_global_3
 extern const LevelScript script_func_global_4[];
+#define group3_load_geolayouts script_func_global_4
 extern const LevelScript script_func_global_5[];
+#define group4_load_geolayouts script_func_global_5
 extern const LevelScript script_func_global_6[];
+#define group5_load_geolayouts script_func_global_6
 extern const LevelScript script_func_global_7[];
+#define group6_load_geolayouts script_func_global_7
 extern const LevelScript script_func_global_8[];
+#define group7_load_geolayouts script_func_global_8
 extern const LevelScript script_func_global_9[];
+#define group8_load_geolayouts script_func_global_9
 extern const LevelScript script_func_global_10[];
+#define group9_load_geolayouts script_func_global_10
 extern const LevelScript script_func_global_11[];
+#define group10_load_geolayouts script_func_global_11
 extern const LevelScript script_func_global_12[];
+#define group11_load_geolayouts script_func_global_12
 extern const LevelScript script_func_global_13[];
+#define group12_load_geolayouts script_func_global_13
 extern const LevelScript script_func_global_14[];
+#define group13_load_geolayouts script_func_global_14
 extern const LevelScript script_func_global_15[];
+#define group14_load_geolayouts script_func_global_15
 extern const LevelScript script_func_global_16[];
+#define group15_load_geolayouts script_func_global_16
 extern const LevelScript script_func_global_17[];
+#define group16_load_geolayouts script_func_global_17
 extern const LevelScript script_func_global_18[];
+#define group17_load_geolayouts script_func_global_18
 
 #endif


### PR DESCRIPTION
(NEEDS TESTING)
 - Fast64 seems to just do its own thing and overwrites the custom macros
    -  (Does Fast64 obsolete this PR entirely?)
- Current implementation adds macros on top of existing ones, but can we replace those without breaking things?
    - `LOAD_GROUPA` and `LOAD_GROUPB` seem unused, would like to hear from users of these macros if they exist

Example Usage would look something like this (only have to write that one command instead of 3)
![image](https://github.com/HackerN64/HackerSM64/assets/9752483/93dc81fe-cee6-4067-9387-088e8442ed0f)
