### PR TITLE
Add mips64-none-elf- to automatically detected prefixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -441,6 +441,8 @@ else ifneq ($(call find-command,mips-linux-gnu-ld),)
   CROSS := mips-linux-gnu-
 else ifneq ($(call find-command,mips64-linux-gnu-ld),)
   CROSS := mips64-linux-gnu-
+else ifneq ($(call find-command,mips64-none-elf-ld),)
+  CROSS := mips64-none-elf-
 else ifneq ($(call find-command,mips-ld),)
   CROSS := mips-
 else


### PR DESCRIPTION
this adds compatibility for embedded toolchains, which compile the repo identically, but have a different name.