### PR TITLE
EASIER_LONG_JUMPS: only long jump with A+Z while running

### DIFF
--- a/src/game/mario_actions_airborne.c
+++ b/src/game/mario_actions_airborne.c
@@ -429,15 +429,6 @@ u32 common_air_action_step(struct MarioState *m, u32 landAction, s32 animation, 
 }
 
 s32 act_jump(struct MarioState *m) {
-#ifdef EASIER_LONG_JUMPS
-    if (m->actionTimer < 1) {
-        m->actionTimer++;
-        if (m->input & INPUT_Z_PRESSED && m->forwardVel > 10.0f) {
-            return set_jumping_action(m, ACT_LONG_JUMP, 0);
-        }
-    }
-#endif
-
     if (check_kick_or_dive_in_air(m)) {
         return TRUE;
     }

--- a/src/game/mario_actions_moving.c
+++ b/src/game/mario_actions_moving.c
@@ -766,6 +766,11 @@ s32 act_walking(struct MarioState *m) {
     }
 
     if (m->input & INPUT_A_PRESSED) {
+#ifdef EASIER_LONG_JUMPS
+        if (m->input & INPUT_Z_PRESSED && m->forwardVel > 10.0f) {
+            return set_mario_action(m, ACT_CROUCH_SLIDE, 0);
+        }
+#endif
         return set_jump_from_landing(m);
     }
 


### PR DESCRIPTION
Originally from: #706

> Pointing to master for the time being.
> 
> Before this define indiscriminately made you long jump any time you pressed Z at the beginning of ACT_JUMP. there are quite a handful of places where ACT_JUMP is started, so it isnt safe to assume you can always first frame check here. Instead - I just do it while running (ACT_WALKING). Keeps it simple and very likely where people get tripped up over this.

> As an extra layer of safety, this cancels into ACT_CROUCH_SLIDE so that the initial crouch slide checks are taken into consideration.