### PR TITLE
Bugfix: Surfaces not able to be placed at the beginning of a partition

### DIFF
--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -88,30 +88,6 @@ static struct Surface *alloc_surface(u32 dynamic) {
 }
 
 /**
- * Iterates through the entire partition, clearing the surfaces.
- */
-static void clear_spatial_partition(SpatialPartitionCell *cells) {
-    register s32 i = sqr(NUM_CELLS);
-
-    while (i--) {
-        (*cells)[SPATIAL_PARTITION_FLOORS] = NULL;
-        (*cells)[SPATIAL_PARTITION_CEILS] = NULL;
-        (*cells)[SPATIAL_PARTITION_WALLS] = NULL;
-        (*cells)[SPATIAL_PARTITION_WATER] = NULL;
-
-        cells++;
-    }
-}
-
-/**
- * Clears the static (level) surface partitions for new use.
- */
-static void clear_static_surfaces(void) {
-    gTotalStaticSurfaceData = 0;
-    clear_spatial_partition(&gStaticSurfacePartition[0][0]);
-}
-
-/**
  * Add a surface to the correct cell list of surfaces.
  * @param dynamic Determines whether the surface is static or dynamic
  * @param cellX The X position of the cell in which the surface resides
@@ -512,7 +488,9 @@ void load_area_terrain(s32 index, TerrainData *data, RoomData *surfaceRooms, s16
     sNumCellsUsed = 0;
     sClearAllCells = TRUE;
 
-    clear_static_surfaces();
+    // Clear the static (level) surface partitions for new use.
+    bzero(gStaticSurfacePartition, sizeof(gStaticSurfacePartition));
+    gTotalStaticSurfaceData = 0;
 
     // Initialise a new surface pool for this block of static surface data
     gCurrStaticSurfacePool = main_pool_alloc(main_pool_available() - 0x10, MEMORY_POOL_LEFT);
@@ -575,7 +553,7 @@ void clear_dynamic_surfaces(void) {
         gSurfaceNodesAllocated = gNumStaticSurfaceNodes;
         gDynamicSurfacePoolEnd = gDynamicSurfacePool;
         if (sClearAllCells) {
-            clear_spatial_partition(&gDynamicSurfacePartition[0][0]);
+            bzero(gDynamicSurfacePartition, sizeof(gDynamicSurfacePartition));
         } else {
             for (u32 i = 0; i < sNumCellsUsed; i++) {
                 gDynamicSurfacePartition[sCellsUsed[i].z][sCellsUsed[i].x][sCellsUsed[i].partition] = NULL;

--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -164,6 +164,14 @@ static void add_surface_to_cell(s32 dynamic, s32 cellX, s32 cellZ, struct Surfac
 
     struct SurfaceNode *curNode = *list;
 
+    // Check if surface should be placed at the beginning of the list.
+    priority = curNode->surface->upperY * sortDir;
+    if (surfacePriority > priority) {
+        *list = newNode;
+        newNode->next = curNode;
+        return;
+    }
+
     // Loop until we find the appropriate place for the surface in the list.
     while (curNode->next != NULL) {
         priority = curNode->next->surface->upperY * sortDir;


### PR DESCRIPTION
Bug introduced as a result of #786.

I've admittedly not noticed any issues that have resulted from this bug thus far in HackerSM64, but it left move rando in absolute shambles when I ported it over. Either way, it's still a bug and may still have hidden consequences.