### PR TITLE
Fix spawned coins not being collectible until after their arc's peak

### DIFF
--- a/src/game/behaviors/coin.inc.c
+++ b/src/game/behaviors/coin.inc.c
@@ -131,7 +131,7 @@ void bhv_coin_loop(void) {
         }
     }
 
-    if (o->oVelY < 0) {
+    if (o->oVelY <= 0) {
         cur_obj_become_tangible();
     }
 


### PR DESCRIPTION
If a spawned coin lands on the same frame it hits the peak of its arc, it will never have vertical speed < 0, so it will never be collectible.

Making this also set the coin to tangible if it has 0 speed fixes this issue.

An example of this bug can be found [here](https://clips.twitch.tv/SpikyBoxyZebraUncleNox-KehYUYBr7DUzRZHG).