### PR TITLE
Fix buggy ledge grabs

### DIFF
--- a/src/game/mario_step.c
+++ b/src/game/mario_step.c
@@ -377,7 +377,6 @@ s32 perform_ground_step(struct MarioState *m) {
 #define hdot_surf(surf, vec) (((surf)->normal.x * (vec)[0]) + ((surf)->normal.z * (vec)[2]))
 
 struct Surface *check_ledge_grab(struct MarioState *m, struct Surface *prevWall, struct Surface *wall, Vec3f intendedPos, Vec3f nextPos, Vec3f ledgePos, struct Surface **ledgeFloor) {
-    struct Surface *returnedWall = wall;
     if (m->vel[1] > 0.0f || wall == NULL) {
         return NULL;
     }
@@ -388,7 +387,7 @@ struct Surface *check_ledge_grab(struct MarioState *m, struct Surface *prevWall,
 
     // Return the already grabbed wall if Mario is moving into it more than the newly tested wall.
     if (hdot_surf(prevWall, m->vel) < hdot_surf(wall, m->vel)) {
-        returnedWall = prevWall;
+        return prevWall;
     }
 
     // Only ledge grab if the wall displaced Mario in the opposite direction of his velocity.
@@ -396,7 +395,7 @@ struct Surface *check_ledge_grab(struct MarioState *m, struct Surface *prevWall,
     if (
         ((nextPos[0] - intendedPos[0]) * m->vel[0]) + ((nextPos[2] - intendedPos[2]) * m->vel[2]) > 0.0f
     ) {
-        returnedWall = prevWall;
+        return prevWall;
     }
 
     ledgePos[0] = nextPos[0] - (wall->normal.x * 60.0f);
@@ -413,7 +412,7 @@ struct Surface *check_ledge_grab(struct MarioState *m, struct Surface *prevWall,
         return NULL;
     }
 
-    return returnedWall;
+    return wall;
 }
 
 #undef hdot_surf


### PR DESCRIPTION
found this bug in mario builder. the ledge grab function checks all collided walls. if you collide with two walls at the same time that can be ledge grabbed, even though the second wall can be "ignored" as the first wall is the one to ledge grab on, the ledge grab position will still be updated and will fuck up the grab