### PR TITLE
Bugfix: assemble_sound.py build corruption issues

### DIFF
--- a/tools/assemble_sound.py
+++ b/tools/assemble_sound.py
@@ -781,9 +781,14 @@ def write_sequences(
     defines,
     is_shindou,
 ):
-    bank_names = sorted(
-        [os.path.splitext(os.path.basename(x))[0] for x in os.listdir(sound_bank_dir)]
+    bank_names = []
+    banks = sorted(
+        [os.path.basename(x) for x in os.listdir(sound_bank_dir)]
     )
+
+    for x in banks:
+        if x.endswith(".json"):
+            bank_names.append(os.path.splitext(x)[0])
 
     try:
         with open(seq_json, "r") as inf:
@@ -841,6 +846,15 @@ def write_sequences(
 
     while ind_to_name and json.get(ind_to_name[-1]) is None:
         ind_to_name.pop()
+
+    if ind_to_name:
+        for x in range(len(ind_to_name)):
+            if ind_to_name[x] is None:
+                fail(
+                    "Sequence file index jump detected. "
+                    + "Please make sure your sequence files are labeled correctly "
+                    + "in incremental hexadecimal order."
+                )
 
     def serialize_file(name, ser, is_shindou):
         if json.get(name) is None:


### PR DESCRIPTION
- Fix Zone.Identifier files counting as a soundbank index
- Throw error if m64 index gap is detected (e.g. when going from `29_mysequence.m64` to `30_mysequence.m64` instead of `2A_mysequence.m64`

Both of these issues are capable of causing game crashes at best, and stealthy yet severe game corruption at worst.