### PR TITLE
Add Fast64 repo settings file (fast64.json)

### DIFF
--- a/fast64.json
+++ b/fast64.json
@@ -1,0 +1,62 @@
+{
+  "version": 1.0,
+  "autoLoad": true,
+  "microcode": "F3DEX2/LX2",
+  "rdpDefaults": {
+    "geometryMode": {
+      "zBuffer": true,
+      "shade": true,
+      "cullBack": true,
+      "lighting": true,
+      "shadeSmooth": true
+    },
+    "otherModeH": {
+      "textureConvert": "G_TC_FILT",
+      "textureFilter": "G_TF_BILERP",
+      "perspectiveCorrection": "G_TP_PERSP",
+      "pipelineMode": "G_PM_1PRIMITIVE"
+    },
+    "otherModeL": {},
+    "other": {}
+  },
+  "sm64": {
+    "draw_layers": {
+      "0": {
+        "cycle_1": "G_RM_ZB_OPA_SURF",
+        "cycle_2": "G_RM_ZB_OPA_SURF2"
+      },
+      "1": {
+        "cycle_1": "G_RM_AA_ZB_OPA_SURF",
+        "cycle_2": "G_RM_AA_ZB_OPA_SURF2"
+      },
+      "2": {
+        "cycle_1": "G_RM_AA_ZB_OPA_DECAL",
+        "cycle_2": "G_RM_AA_ZB_OPA_DECAL2"
+      },
+      "3": {
+        "cycle_1": "G_RM_AA_ZB_OPA_INTER",
+        "cycle_2": "G_RM_AA_ZB_OPA_INTER2"
+      },
+      "4": {
+        "cycle_1": "G_RM_AA_ZB_TEX_EDGE",
+        "cycle_2": "G_RM_AA_ZB_TEX_EDGE2"
+      },
+      "5": {
+        "cycle_1": "G_RM_AA_ZB_XLU_SURF",
+        "cycle_2": "G_RM_AA_ZB_XLU_SURF2"
+      },
+      "6": {
+        "cycle_1": "G_RM_AA_ZB_XLU_DECAL",
+        "cycle_2": "G_RM_AA_ZB_XLU_DECAL2"
+      },
+      "7": {
+        "cycle_1": "G_RM_AA_ZB_XLU_INTER",
+        "cycle_2": "G_RM_AA_ZB_XLU_INTER2"
+      }
+    },
+    "refresh_version": "Refresh 13",
+    "compression_format": "mio0",
+    "force_extended_ram": false,
+    "matstack_fix": true
+  }
+}

--- a/fast64.json
+++ b/fast64.json
@@ -20,7 +20,7 @@
     "other": {}
   },
   "sm64": {
-    "refresh_version": "Refresh 13",
+    "refresh_version": "HackerSM64 2.3.0",
     "compression_format": "yay0",
     "force_extended_ram": false,
     "matstack_fix": true

--- a/fast64.json
+++ b/fast64.json
@@ -21,7 +21,7 @@
   },
   "sm64": {
     "refresh_version": "Refresh 13",
-    "compression_format": "mio0",
+    "compression_format": "yay0",
     "force_extended_ram": false,
     "matstack_fix": true
   }

--- a/fast64.json
+++ b/fast64.json
@@ -20,40 +20,6 @@
     "other": {}
   },
   "sm64": {
-    "draw_layers": {
-      "0": {
-        "cycle_1": "G_RM_ZB_OPA_SURF",
-        "cycle_2": "G_RM_ZB_OPA_SURF2"
-      },
-      "1": {
-        "cycle_1": "G_RM_AA_ZB_OPA_SURF",
-        "cycle_2": "G_RM_AA_ZB_OPA_SURF2"
-      },
-      "2": {
-        "cycle_1": "G_RM_AA_ZB_OPA_DECAL",
-        "cycle_2": "G_RM_AA_ZB_OPA_DECAL2"
-      },
-      "3": {
-        "cycle_1": "G_RM_AA_ZB_OPA_INTER",
-        "cycle_2": "G_RM_AA_ZB_OPA_INTER2"
-      },
-      "4": {
-        "cycle_1": "G_RM_AA_ZB_TEX_EDGE",
-        "cycle_2": "G_RM_AA_ZB_TEX_EDGE2"
-      },
-      "5": {
-        "cycle_1": "G_RM_AA_ZB_XLU_SURF",
-        "cycle_2": "G_RM_AA_ZB_XLU_SURF2"
-      },
-      "6": {
-        "cycle_1": "G_RM_AA_ZB_XLU_DECAL",
-        "cycle_2": "G_RM_AA_ZB_XLU_DECAL2"
-      },
-      "7": {
-        "cycle_1": "G_RM_AA_ZB_XLU_INTER",
-        "cycle_2": "G_RM_AA_ZB_XLU_INTER2"
-      }
-    },
     "refresh_version": "Refresh 13",
     "compression_format": "mio0",
     "force_extended_ram": false,


### PR DESCRIPTION
Allows fast64 to know a repo's ideal settings as soon as decomp path is picked. Settings are the default except for:

- Matstack Fix is on
- Microcode is set to EX2
- Force Extended RAM is off because hackersm64 already has it enabled by default
- Refresh is set to HackerSM64 2.3.0 (Refresh 13)