### PR TITLE
bhvStarSpawnOverride

### DIFF
--- a/data/behavior_data.c
+++ b/data/behavior_data.c
@@ -4554,6 +4554,12 @@ const BehaviorScript bhvStarSpawnCoordinates[] = {
     END_LOOP(),
 };
 
+const BehaviorScript bhvStarSpawnOverride[] = {
+    BEGIN(OBJ_LIST_DEFAULT),
+    OR_INT(oFlags, (OBJ_FLAG_UPDATE_GFX_POS_AND_ANGLE)),
+    BREAK(),
+};
+
 const BehaviorScript bhvHiddenRedCoinStar[] = {
     BEGIN(OBJ_LIST_LEVEL),
     OR_INT(oFlags, (OBJ_FLAG_PERSISTENT_RESPAWN | OBJ_FLAG_UPDATE_GFX_POS_AND_ANGLE)),

--- a/include/behavior_data.h
+++ b/include/behavior_data.h
@@ -400,6 +400,7 @@ extern const BehaviorScript bhvNormalCap[];
 extern const BehaviorScript bhvVanishCap[];
 extern const BehaviorScript bhvStar[];
 extern const BehaviorScript bhvStarSpawnCoordinates[];
+extern const BehaviorScript bhvStarSpawnOverride[];
 extern const BehaviorScript bhvHiddenRedCoinStar[];
 extern const BehaviorScript bhvRedCoin[];
 extern const BehaviorScript bhvBowserCourseRedCoinStar[];

--- a/src/game/behaviors/spawn_star.inc.c
+++ b/src/game/behaviors/spawn_star.inc.c
@@ -134,7 +134,14 @@ struct Object *spawn_star(struct Object *starObj, f32 x, f32 y, f32 z) {
 
 void spawn_default_star(f32 x, f32 y, f32 z) {
     struct Object *starObj = NULL;
-    starObj = spawn_star(starObj, x, y, z);
+    struct Object *override = NULL;
+    override = cur_obj_nearest_object_with_behavior(bhvStarSpawnOverride);
+    if(!override){
+        starObj = spawn_star(starObj, x, y, z);
+    } else {
+        starObj = spawn_star(starObj, override->oPosX, override->oPosY, override->oPosZ);
+        obj_mark_for_deletion(override);
+    }
     starObj->oBehParams2ndByte = SPAWN_STAR_ARC_CUTSCENE_BP_DEFAULT_STAR;
 }
 


### PR DESCRIPTION
Working on #686 in chunks.

First Chunk: hardcoded star positions

Basically the functionality here is place an empty with bhvStarSpawnOverride, and that's where the star will spawn, done.
If bhvStarSpawnOverride is not found, spawn_default_star uses the hardcoded positions as usual.