### PR TITLE
Make G_PM_NPRIMITIVE a world default for fast64 exports

### DIFF
--- a/fast64.json
+++ b/fast64.json
@@ -14,7 +14,7 @@
       "textureConvert": "G_TC_FILT",
       "textureFilter": "G_TF_BILERP",
       "perspectiveCorrection": "G_TP_PERSP",
-      "pipelineMode": "G_PM_1PRIMITIVE"
+      "pipelineMode": "G_PM_NPRIMITIVE"
     },
     "otherModeL": {},
     "other": {}


### PR DESCRIPTION
HackerSM64 should not be reverting back to 1prim if ever overridden in fast64 (for some reason)