### PR TITLE
[3.0] Added support for C23

### DIFF
--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -224,7 +224,7 @@ void create_dl_ortho_matrix(void) {
  * Returns the table entry of the relevant character.
  * Also increments the string position by the correct amount to reach the next character.
  */
-struct Utf8CharLUTEntry *utf8_lookup(struct Utf8LUT *lut, char *str, s32 *strPos) {
+struct Utf8CharLUTEntry *utf8_lookup(const struct Utf8LUT *lut, const char *str, s32 *strPos) {
     u32 codepoint;
     struct Utf8CharLUTEntry *usedLUT;
     u32 length;
@@ -291,7 +291,7 @@ static s32 hex_char_to_value(char c) {
  * Convert two hexadecimal text characters into an integer. Returns -1 if either of the two characters
  * aren't hexadecimal values.
  */
-static s32 hex_pair_to_value(char *str, s32 strPos) {
+static s32 hex_pair_to_value(const char *str, s32 strPos) {
     s32 firstDigit = hex_char_to_value(str[strPos]);
     s32 secondDigit = hex_char_to_value(str[strPos + 1]);
 
@@ -305,7 +305,7 @@ static s32 hex_pair_to_value(char *str, s32 strPos) {
 /**
  * Determine if the characters following a color command are a valid hex color code.
  */
-static s32 is_color_code_valid(char *str, s32 strPos) {
+static s32 is_color_code_valid(const char *str, s32 strPos) {
     for (u32 i = 0; i < sizeof(gDialogCarryoverColor) * 2; i++) {
         if (hex_char_to_value(str[strPos + i]) == -1) {
             if (i < sizeof(ColorRGB) * 2) return FALSE;
@@ -332,7 +332,7 @@ void set_text_color(u32 r, u32 g, u32 b) {
 /**
  * Get the exact width of the line of a string of any font in pixels, using the given ASCII and UTF-8 tables.
  */
-s32 get_string_width(char *str, struct AsciiCharLUTEntry *asciiLut, struct Utf8LUT *utf8LUT) {
+s32 get_string_width(const char *str, const struct AsciiCharLUTEntry *asciiLut, const struct Utf8LUT *utf8LUT) {
     char c;
     s32 width = 0;
     s32 maxWidth = 0;
@@ -371,7 +371,7 @@ s32 get_string_width(char *str, struct AsciiCharLUTEntry *asciiLut, struct Utf8L
 /**
  * Get the value to shift the X position of a string by, given a specific alignment.
  */
-static s32 get_alignment_x_offset(char *str, u32 alignment, struct AsciiCharLUTEntry *asciiLut, struct Utf8LUT *utf8LUT) {
+static s32 get_alignment_x_offset(const char *str, u32 alignment, const struct AsciiCharLUTEntry *asciiLut, const struct Utf8LUT *utf8LUT) {
     if (alignment == TEXT_ALIGN_LEFT) {
         return 0;
     }
@@ -455,7 +455,7 @@ static u8 *alloc_ia8_text_from_i1(u16 *in, s16 width, s16 height) {
  * Renders a single ASCII character in the generic font.
  */
 static u32 render_generic_ascii_char(char c) {
-    struct AsciiCharLUTEntry *fontLUT = segmented_to_virtual(main_font_lut);
+    const struct AsciiCharLUTEntry *fontLUT = segmented_to_virtual(main_font_lut);
     const Texture *texture = fontLUT[ASCII_LUT_INDEX(c)].texture;
 
     if (texture != NULL) {
@@ -470,7 +470,7 @@ static u32 render_generic_ascii_char(char c) {
 /**
  * Renders a single UTF-8 character in the generic font.
  */
-static u32 render_generic_unicode_char(char *str, s32 *strPos) {
+static u32 render_generic_unicode_char(const char *str, s32 *strPos) {
     struct Utf8CharLUTEntry *utf8Entry = utf8_lookup(&main_font_utf8_lut, str, strPos);
 
     if (utf8Entry->texture == NULL) {
@@ -537,7 +537,7 @@ static u32 render_generic_unicode_char(char *str, s32 *strPos) {
  * Uses the global variables sGenericFontLineHeight and sGenericFontLineAlignment 
  * to control printing.
  */
-static s32 render_main_font_text(s16 x, s16 y, char *str, s32 maxLines) {
+static s32 render_main_font_text(s16 x, s16 y, const char *str, s32 maxLines) {
     char c;
     s8 kerning = 0;
     u8 queuedSpaces = 0; // Optimization to only have one translation matrix if there are multiple spaces in a row.
@@ -686,21 +686,21 @@ render_character:
 /**
  * Prints a generic white string.
  */
-void print_generic_string(s16 x, s16 y, char *str) {
+void print_generic_string(s16 x, s16 y, const char *str) {
     print_generic_string_aligned(x, y, str, TEXT_ALIGN_LEFT);
 }
 
 /**
  * Prints a hud string in the colorful font.
  */
-void print_hud_lut_string(s16 x, s16 y, char *str) {
+void print_hud_lut_string(s16 x, s16 y, const char *str) {
     s32 strPos = 0;
     char c;
-    struct AsciiCharLUTEntry *hudLUT = segmented_to_virtual(main_hud_lut); // 0-9 A-Z HUD Color Font
+    const struct AsciiCharLUTEntry *hudLUT = segmented_to_virtual(main_hud_lut); // 0-9 A-Z HUD Color Font
     u32 curX = x;
     u32 curY = y;
     u32 renderX, renderY;
-    struct Utf8CharLUTEntry *utf8Entry;
+    const struct Utf8CharLUTEntry *utf8Entry;
     const Texture *texture;
     u32 kerning;
     Gfx *gfx = gDisplayListHead;
@@ -766,7 +766,7 @@ void print_hud_lut_string(s16 x, s16 y, char *str) {
  * Renders a single ASCII character in the menu font.
  */
 static u32 render_menu_ascii_char(char c, u32 curX, u32 curY) {
-    struct AsciiCharLUTEntry *fontLUT = segmented_to_virtual(menu_font_lut);
+    const struct AsciiCharLUTEntry *fontLUT = segmented_to_virtual(menu_font_lut);
     const Texture *texture = fontLUT[ASCII_LUT_INDEX(c)].texture;
 
     if (texture != NULL) {
@@ -783,7 +783,7 @@ static u32 render_menu_ascii_char(char c, u32 curX, u32 curY) {
 /**
  * Renders a single UTF-8 character in the menu font.
  */
-static u32 render_menu_unicode_char(char *str, s32 *strPos, u32 curX, u32 curY) {
+static u32 render_menu_unicode_char(const char *str, s32 *strPos, u32 curX, u32 curY) {
     struct Utf8CharLUTEntry *utf8Entry = utf8_lookup(&menu_font_utf8_lut, str, strPos);
 
     if (utf8Entry->texture == NULL) {
@@ -811,7 +811,7 @@ static u32 render_menu_unicode_char(char *str, s32 *strPos, u32 curX, u32 curY) 
  * Prints a menu white string in the smaller font.
  * Only available in the file select and star select menus.
  */
-void print_menu_generic_string(s16 x, s16 y, char *str) {
+void print_menu_generic_string(s16 x, s16 y, const char *str) {
     s32 strPos = 0;
     char c;
     u32 curX = x;
@@ -833,10 +833,10 @@ void print_menu_generic_string(s16 x, s16 y, char *str) {
 /**
  * Prints a string in the green credits font.
  */
-void print_credits_string(s16 x, s16 y, char *str) {
+void print_credits_string(s16 x, s16 y, const char *str) {
     s32 strPos = 0;
     char c;
-    struct AsciiCharLUTEntry *fontLUT = segmented_to_virtual(main_credits_font_lut);
+    const struct AsciiCharLUTEntry *fontLUT = segmented_to_virtual(main_credits_font_lut);
     u32 curX = x;
     u32 curY = y;
 
@@ -865,23 +865,23 @@ void print_credits_string(s16 x, s16 y, char *str) {
 /**
  * Variants of the above that allow for text alignment.
  */
-void print_generic_string_aligned(s16 x, s16 y, char *str, u32 alignment) {
+void print_generic_string_aligned(s16 x, s16 y, const char *str, u32 alignment) {
     sGenericFontLineHeight = DIALOG_LINE_HEIGHT_EN;
     sGenericFontLineAlignment = alignment;
     render_main_font_text(x, y, str, -1);
 }
 
-void print_hud_lut_string_aligned(s16 x, s16 y, char *str, u32 alignment) {
+void print_hud_lut_string_aligned(s16 x, s16 y, const char *str, u32 alignment) {
     x += get_alignment_x_offset(str, alignment, main_hud_lut, &main_hud_utf8_lut);
     print_hud_lut_string(x, y, str);
 }
 
-void print_menu_generic_string_aligned(s16 x, s16 y, char *str, u32 alignment) {
+void print_menu_generic_string_aligned(s16 x, s16 y, const char *str, u32 alignment) {
     x += get_alignment_x_offset(str, alignment, menu_font_lut, &menu_font_utf8_lut);
     print_menu_generic_string(x, y, str);
 }
 
-void print_credits_string_aligned(s16 x, s16 y, char *str, u32 alignment) {
+void print_credits_string_aligned(s16 x, s16 y, const char *str, u32 alignment) {
     x += get_alignment_x_offset(str, alignment, main_credits_font_lut, NULL);
     print_credits_string(x, y, str);
 }
@@ -975,7 +975,7 @@ void create_dialog_box_with_int_var(s16 dialog, s32 dialogVar) {
 /**
  * Initialise a dialog box with a string variable to be displayed with %s.
  */
-void create_dialog_box_with_str_var(s16 dialog, char *dialogVar) {
+void create_dialog_box_with_str_var(s16 dialog, const char *dialogVar) {
     DialogVariable var = { .asStr = dialogVar };
     create_dialog_box_with_var(dialog, var);
 }
@@ -1025,7 +1025,7 @@ void reset_dialog_render_state(void) {
     gDialogResponse = DIALOG_RESPONSE_NONE;
 }
 
-void render_dialog_box_type(struct DialogEntry *dialog, s8 linesPerBox) {
+void render_dialog_box_type(const struct DialogEntry *dialog, s8 linesPerBox) {
     create_dl_translation_matrix(MENU_MTX_NOPUSH, dialog->leftOffset, dialog->width, 0);
 
     switch (gDialogBoxType) {
@@ -1058,8 +1058,8 @@ u32 ensure_nonnegative(s16 value) {
     return ((value < 0) ? 0 : value);
 }
 
-static void handle_dialog_text_and_pages(struct DialogEntry *dialog) {
-    char *str = segmented_to_virtual(dialog->str);
+static void handle_dialog_text_and_pages(const struct DialogEntry *dialog) {
+    const char *str = segmented_to_virtual(dialog->str);
     s8 totalLines;
     s32 printResult;
     s16 yPos = 2 - DIALOG_LINE_HEIGHT;
@@ -1269,8 +1269,8 @@ s8  gDialogCameraAngleIndex = CAM_SELECTION_MARIO;
 s8  gDialogCourseActNum     =  1;
 
 void render_dialog_entries(void) {
-    void **dialogTable = segmented_to_virtual(gLanguageTables[gInGameLanguage].dialog_table);
-    struct DialogEntry *dialog = segmented_to_virtual(dialogTable[gDialogID]);
+    const void **dialogTable = segmented_to_virtual(gLanguageTables[gInGameLanguage].dialog_table);
+    const struct DialogEntry *dialog = segmented_to_virtual(dialogTable[gDialogID]);
 
     // if the dialog entry is invalid, set the ID to DIALOG_NONE.
     if (segmented_to_virtual(NULL) == dialog) {
@@ -1450,8 +1450,8 @@ void do_cutscene_handler(void) {
 // "Dear Mario" message handler
 void print_peach_letter_message(void) {
     void **dialogTable = segmented_to_virtual(gLanguageTables[gInGameLanguage].dialog_table);
-    struct DialogEntry *dialog = segmented_to_virtual(dialogTable[gDialogID]);
-    char *str = segmented_to_virtual(dialog->str);
+    const struct DialogEntry *dialog = segmented_to_virtual(dialogTable[gDialogID]);
+    const char *str = segmented_to_virtual(dialog->str);
 
     create_dl_translation_matrix(MENU_MTX_PUSH, 97.0f, 118.0f, 0);
 
@@ -1676,7 +1676,7 @@ void render_pause_my_score_coins(void) {
 
     set_text_color(255, 255, 255);
 
-    char *courseName = segmented_to_virtual(courseNameTbl[courseIndex]);
+    const char *courseName = segmented_to_virtual(courseNameTbl[courseIndex]);
 
     if (courseIndex <= COURSE_NUM_TO_INDEX(COURSE_STAGES_MAX)) {
         char courseNumText[8];
@@ -1684,7 +1684,7 @@ void render_pause_my_score_coins(void) {
         sprintf(str, LANG_ARRAY(textCourseX), courseNumText);
         print_generic_string_aligned(PAUSE_MENU_LEFT_X, PAUSE_MENU_COURSE_Y, str, TEXT_ALIGN_RIGHT);
 
-        char *actName = segmented_to_virtual(actNameTbl[COURSE_NUM_TO_INDEX(gCurrCourseNum) * 6 + gDialogCourseActNum - 1]);
+        const char *actName = segmented_to_virtual(actNameTbl[COURSE_NUM_TO_INDEX(gCurrCourseNum) * 6 + gDialogCourseActNum - 1]);
 
         if (starFlags & (1 << (gDialogCourseActNum - 1))) {
             print_generic_string_aligned(PAUSE_MENU_LEFT_X, PAUSE_MENU_ACT_Y, "★", TEXT_ALIGN_RIGHT);
@@ -1862,7 +1862,7 @@ void render_pause_castle_course_stars(s16 x, s16 y, s16 fileIndex, s16 courseInd
     s16 hasStar = 0;
 
     char str[30];
-    char *entries[6];
+    const char *entries[6];
 
     u8 starFlags = save_file_get_star_flags(fileIndex, courseIndex);
     u16 starCount = save_file_get_course_star_count(fileIndex, courseIndex);
@@ -2171,7 +2171,7 @@ LangArray textClear = DEFINE_LANGUAGE_ARRAY(
 #define CONGRATULATIONS_COINS_Y 111
 
 void render_course_complete_lvl_info_and_hud_str(void) {
-    char *name;
+    const char *name;
 
     char str[20];
     char courseNumText[8];

--- a/src/game/ingame_menu.h
+++ b/src/game/ingame_menu.h
@@ -85,9 +85,9 @@ extern s8 gDialogCourseActNum;
 extern u8 gInGameLanguage;
 
 struct LanguageTables {
-    /* 0x00 */ u8 *dialog_table;
-    /* 0x01 */ u8 *course_name_table;
-    /* 0x02 */ u8 *act_name_table;
+    /* 0x00 */ const u8 *dialog_table;
+    /* 0x01 */ const u8 *course_name_table;
+    /* 0x02 */ const u8 *act_name_table;
 }; /* 0x03 */
 
 extern const struct LanguageTables gLanguageTables[];
@@ -107,23 +107,23 @@ struct Utf8CharLUTEntry {
     u32 codepoint;
     s8 kerning;
     u16 flags; // used for diacritics and packed textures
-    Texture *texture;
+    const Texture *texture;
 };
 
 struct Utf8LUT {
-    struct Utf8CharLUTEntry *lut2Bytes;
-    struct Utf8CharLUTEntry *lut3Bytes;
-    struct Utf8CharLUTEntry *lut4Bytes;
+    const struct Utf8CharLUTEntry *lut2Bytes;
+    const struct Utf8CharLUTEntry *lut3Bytes;
+    const struct Utf8CharLUTEntry *lut4Bytes;
     u16 length2Bytes; // set these with the ARRAY_COUNT macro
     u16 length3Bytes;
     u16 length4Bytes;
-    struct Utf8CharLUTEntry *missingChar;
+    const struct Utf8CharLUTEntry *missingChar;
 };
 
 struct DiacriticLUTEntry {
     s8 xOffset;
     s8 yOffset;
-    char *str;
+    const char *str;
 };
 
 enum TextDiacriticMarks {
@@ -215,7 +215,7 @@ enum MultilangLanguages {
 #define LANG_ARRAY_COND_SPANISH(...)
 #endif
 
-typedef char * LangArray[LANGUAGE_COUNT];
+typedef const char * LangArray[LANGUAGE_COUNT];
 #define LANG_ARRAY(cmd) ((cmd)[gInGameLanguage])
 #define DEFINE_LANGUAGE_ARRAY(english, french, german, japanese, spanish) { \
     [LANGUAGE_ENGLISH] = english,                                           \
@@ -230,7 +230,7 @@ typedef char * LangArray[LANGUAGE_COUNT];
 // If multilang is off, ignore all other languages and only include English.
 #define LANGUAGE_ENGLISH 0
 
-typedef char * LangArray;
+typedef const char * LangArray;
 #define LANG_ARRAY(cmd) (cmd)
 #define DEFINE_LANGUAGE_ARRAY(english, french, german, japanese, spanish) english
 
@@ -254,7 +254,7 @@ typedef char * LangArray;
 
 typedef union {
     s32 asInt;
-    char *asStr;
+    const char *asStr;
 } DialogVariable;
 
 extern s32 gDialogResponse;
@@ -270,23 +270,23 @@ void create_dl_ortho_matrix(void);
 void create_dl_scale_matrix(s8 pushOp, f32 x, f32 y, f32 z);
 
 void set_text_color(u32 r, u32 g, u32 b);
-s32 get_string_width(char *str, struct AsciiCharLUTEntry *asciiLut, struct Utf8LUT *utf8LUT);
+s32 get_string_width(const char *str, const struct AsciiCharLUTEntry *asciiLut, const struct Utf8LUT *utf8LUT);
 void format_int_to_string(char *buf, s32 value);
-void print_generic_string(s16 x, s16 y, char *str);
-void print_hud_lut_string(s16 x, s16 y, char *str);
-void print_menu_generic_string(s16 x, s16 y, char *str);
-void print_credits_string(s16 x, s16 y, char *str);
-void print_generic_string_aligned(s16 x, s16 y, char *str, u32 alignment);
-void print_hud_lut_string_aligned(s16 x, s16 y, char *str, u32 alignment);
-void print_menu_generic_string_aligned(s16 x, s16 y, char *str, u32 alignment);
-void print_credits_string_aligned(s16 x, s16 y, char *str, u32 alignment);
+void print_generic_string(s16 x, s16 y, const char *str);
+void print_hud_lut_string(s16 x, s16 y, const char *str);
+void print_menu_generic_string(s16 x, s16 y, const char *str);
+void print_credits_string(s16 x, s16 y, const char *str);
+void print_generic_string_aligned(s16 x, s16 y, const char *str, u32 alignment);
+void print_hud_lut_string_aligned(s16 x, s16 y, const char *str, u32 alignment);
+void print_menu_generic_string_aligned(s16 x, s16 y, const char *str, u32 alignment);
+void print_credits_string_aligned(s16 x, s16 y, const char *str, u32 alignment);
 
 void handle_menu_scrolling(s8 scrollDirection, s8 *currentIndex, s8 minIndex, s8 maxIndex);
 void print_hud_my_score_coins(s32 useCourseCoinScore, s8 fileIndex, s8 courseIndex, s16 x, s16 y);
 s32 get_dialog_id(void);
 void create_dialog_box(s16 dialog);
 void create_dialog_box_with_int_var(s16 dialog, s32 dialogVar);
-void create_dialog_box_with_str_var(s16 dialog, char *dialogVar);
+void create_dialog_box_with_str_var(s16 dialog, const char *dialogVar);
 void create_dialog_box_with_var(s16 dialog, DialogVariable dialogVar);
 void create_dialog_inverted_box(s16 dialog);
 void create_dialog_box_with_response(s16 dialog);

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -132,7 +132,7 @@ struct MarioState gMarioStates[1];
 struct HudDisplay gHudDisplay;
 s16 sCurrPlayMode;
 s16 sTransitionTimer;
-void (*sTransitionUpdate)(s16 *);
+void (*sTransitionUpdate)(void);
 struct WarpDest sWarpDest;
 s16 sSpecialWarpDest;
 s16 sDelayedWarpOp;
@@ -1134,7 +1134,7 @@ s32 play_mode_frame_advance(void) {
  * but before it actually occurs. If updateFunction is not NULL, it will be
  * called each frame during the transition.
  */
-void level_set_transition(s16 length, void (*updateFunction)()) {
+void level_set_transition(s16 length, void (*updateFunction)(void)) {
     sTransitionTimer = length;
     sTransitionUpdate = updateFunction;
 }
@@ -1146,7 +1146,7 @@ s32 play_mode_change_area(void) {
     // sm64ex-alo
     // Change function to have similar change_level defines
     if (sTransitionUpdate != NULL) {
-        sTransitionUpdate(&sTransitionTimer);
+        sTransitionUpdate();
     }
 
     if (--sTransitionTimer == -1) {
@@ -1164,7 +1164,7 @@ s32 play_mode_change_area(void) {
  */
 s32 play_mode_change_level(void) {
     if (sTransitionUpdate != NULL) {
-        sTransitionUpdate(&sTransitionTimer);
+        sTransitionUpdate();
     }
 
     if (--sTransitionTimer == -1) {

--- a/src/game/level_update.h
+++ b/src/game/level_update.h
@@ -88,7 +88,7 @@ extern struct MarioState *gMarioState;
 
 extern s16 sCurrPlayMode;
 extern s16 sTransitionTimer;
-extern void (*sTransitionUpdate)(s16 *);
+extern void (*sTransitionUpdate)(void);
 extern void load_language_text(void);
 
 struct WarpDest {
@@ -174,7 +174,7 @@ u16 level_control_timer(s32 timerOp);
 void fade_into_special_warp(u32 arg, u32 color);
 void load_level_init_text(u32 arg);
 s16 level_trigger_warp(struct MarioState *m, s32 warpOp);
-void level_set_transition(s16 length, void (*updateFunction)());
+void level_set_transition(s16 length, void (*updateFunction)(void));
 
 s32 lvl_init_or_update(                  s16 initOrUpdate, UNUSED s32 levelNum);
 s32 lvl_init_from_save_file(      UNUSED s16 initOrUpdate,        s32 levelNum);

--- a/src/game/print.c
+++ b/src/game/print.c
@@ -32,7 +32,7 @@ s16 sTextLabelsCount = 0;
  * Takes a number, formats the number, and prints it
  * at the given X & Y coordinates.
  */
-void print_text_fmt_int(s32 x, s32 y, char *str, s32 n) {
+void print_text_fmt_int(s32 x, s32 y, const char *str, s32 n) {
     char buffer[MAX_TEXT_LABEL_SIZE];
     sprintf(buffer, str, n);
     print_text(x, y, buffer);
@@ -41,7 +41,7 @@ void print_text_fmt_int(s32 x, s32 y, char *str, s32 n) {
 /**
  * Prints text in the colorful lettering at given X, Y coordinates.
  */
-void print_text(s32 x, s32 y, char *str) {
+void print_text(s32 x, s32 y, const char *str) {
     // Don't continue if there is no memory to do so.
     if ((sTextLabels[sTextLabelsCount] = mem_pool_alloc(gEffectsMemoryPool,
                                                         sizeof(struct TextLabel))) == NULL) {
@@ -64,7 +64,7 @@ void print_text(s32 x, s32 y, char *str) {
 /**
  * Prints text in the colorful lettering, allowing for text alignment.
  */
-void print_text_aligned(s32 x, s32 y, char *str, u32 alignment) {
+void print_text_aligned(s32 x, s32 y, const char *str, u32 alignment) {
     s32 strLength = get_string_width(str, main_hud_lut, &main_hud_utf8_lut);
     if (alignment == TEXT_ALIGN_RIGHT) {
         x -= strLength;

--- a/src/game/print.h
+++ b/src/game/print.h
@@ -3,9 +3,9 @@
 
 #include <PR/ultratypes.h>
 
-void print_text_fmt_int(s32 x, s32 y, char *str, s32 n);
-void print_text(s32 x, s32 y, char *str);
-void print_text_aligned(s32 x, s32 y, char *str, u32 alignment);
+void print_text_fmt_int(s32 x, s32 y, const char *str, s32 n);
+void print_text(s32 x, s32 y, const char *str);
+void print_text_aligned(s32 x, s32 y, const char *str, u32 alignment);
 void render_text_labels(void);
 
 #endif // PRINT_H

--- a/src/menu/file_select.c
+++ b/src/menu/file_select.c
@@ -1177,7 +1177,7 @@ void print_menu_cursor(void) {
  * Takes a number between 0 and 3 and formats the corresponding file letter A to D into a buffer.
  * If the language is set to Japanese, the letter is written in full-width digits.
  */
-void string_format_file_letter(char *buf, char *str, s32 fileIndex) {
+void string_format_file_letter(char *buf, const char *str, s32 fileIndex) {
     char letterBuf[4];
 #ifdef ENABLE_JAPANESE
     if (gInGameLanguage == LANGUAGE_JAPANESE) {
@@ -1199,7 +1199,7 @@ void string_format_file_letter(char *buf, char *str, s32 fileIndex) {
 /**
  * Prints a hud string with text fade properties.
  */
-void print_hud_lut_string_fade(s16 x, s16 y, char *text, u32 alignment) {
+void print_hud_lut_string_fade(s16 x, s16 y, const char *text, u32 alignment) {
     gSPDisplayList(gDisplayListHead++, dl_rgba16_text_begin);
     gDialogTextAlpha -= sTextFadeAlpha;
     gDPSetEnvColor(gDisplayListHead++, 255, 255, 255, gDialogTextAlpha);
@@ -1211,7 +1211,7 @@ void print_hud_lut_string_fade(s16 x, s16 y, char *text, u32 alignment) {
 /**
  * Prints a generic white string with text fade properties.
  */
-void print_generic_string_fade(s16 x, s16 y, char *text, u32 alignment) {
+void print_generic_string_fade(s16 x, s16 y, const char *text, u32 alignment) {
     gSPDisplayList(gDisplayListHead++, dl_ia_text_begin);
     gDialogTextAlpha -= sTextFadeAlpha;
     set_text_color(255, 255, 255);


### PR DESCRIPTION
Closes #911 for 3.0 branch. Still requires merge in from 2.4.x but intentionally omitted to avoid merge conflicts.

 * Fixed constness missing in print-like functions causing compilation issues with `print_text(20, 20, "TEST")` pattern.
 * Fixed incorrect function type for sTransitionUpdate.