### PR TITLE
Bugfix: Stale reference to gCamera during profiling upon game over

### DIFF
--- a/src/game/area.c
+++ b/src/game/area.c
@@ -181,6 +181,7 @@ void clear_areas(void) {
     gWarpTransition.isActive = FALSE;
     gWarpTransition.pauseRendering = FALSE;
     gMarioSpawnInfo->areaIndex = -1;
+    gCamera = NULL;
 
     for (i = 0; i < AREA_COUNT; i++) {
         gAreaData[i].index = i;

--- a/src/game/profiling.c
+++ b/src/game/profiling.c
@@ -182,7 +182,7 @@ static void update_rdp_timers() {
 }
 
 float profiler_get_fps() {
-    return (1000000.0f * PROFILING_BUFFER_SIZE) / (OS_CYCLES_TO_USEC(all_profiling_data[PROFILER_TIME_FPS].total));
+    return (1000000.0f * PROFILING_BUFFER_SIZE) / MAX(OS_CYCLES_TO_USEC(all_profiling_data[PROFILER_TIME_FPS].total), 1);
 }
 
 u32 profiler_get_cpu_cycles() {
@@ -288,7 +288,7 @@ void profiler_print_times() {
             "RSP\t\t%d (%d%%)\n"
             " Gfx\t\t\t%d\n"
             " Audio\t\t\t%d\n",
-            1000000.0f / microseconds[PROFILER_TIME_FPS],
+            1000000.0f / MAX(microseconds[PROFILER_TIME_FPS], 1),
             total_cpu, total_cpu / 333, 
             microseconds[PROFILER_TIME_CONTROLLERS],
 #ifdef PUPPYPRINT_DEBUG

--- a/src/game/puppyprint.c
+++ b/src/game/puppyprint.c
@@ -535,7 +535,7 @@ void render_coverage_map(void) {
 void puppycamera_debug_view(void) {
     char textBytes[80];
     // Very little point printing useless info if Mayro doesn't even exist.
-    if (gMarioState->marioObj) {
+    if (gMarioObject) {
         sprintf(textBytes, "Mario Pos\nX: %d\nY: %d\nZ: %d\nD: %X\nA: %x",
             (s32)(gMarioState->pos[0]),
             (s32)(gMarioState->pos[1]),
@@ -1006,7 +1006,7 @@ void puppyprint_render_general_vars(void) {
 
 #ifndef ENABLE_CREDITS_BENCHMARK
     // Very little point printing useless info if Mario doesn't even exist.
-    if (gMarioState->marioObj) {
+    if (gMarioObject) {
         sprintf(textBytes, "Mario\n\nX: %d\nY: %d\nZ: %d\nYaw: 0x%04X\n\nfVel: %1.1f\nyVel: %1.1f\n\nHealth: %03X\nAction: 0x%02X\nFloor Type: 0x%02X\nWater Height: %d",
             (s32)(gMarioState->pos[0]),
             (s32)(gMarioState->pos[1]),


### PR DESCRIPTION
`gCamera` never gets reset to NULL upon game over, which crashes the profiler on console. Time to fix that!